### PR TITLE
Make license copyright generic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Collin Valley
+Copyright (c) 2019 route-rs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Copyright is jointly held between all contributors, the LICENSE file
should reflect that.