### PR TITLE
Support Async Elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # route-rs
+
 A multithreaded, modular software defined router library, written in rust.  Safe, fast, and extensible.
 
 Original click modular router: https://github.com/kohler/click
@@ -6,7 +7,13 @@ Click Paper: https://dl.acm.org/citation.cfm?id=354874
 
 We plan to follow the general concepts of Click, but we want to build Route-rs the way that Click would be built today.
 Namely:
+
 * Concurrency by default (Using Tokio-rs as a runtime)
 * Type safe (Written in Rust)
 * Easily Extensible
 * Runs in userspace
+
+Much like the original Click, units of computation are loosely defined around `elements`, which are objects that
+implement the `process` function. `Elements` are wrapped by `ElementLink`s, which is what the library will use to chain computation together, producing a functioning, modular, software-defined router. `Elements` come in either synchronous or asynchronous flavors. In general, synchronous `elements` should be used for short transformations; asynchronous `elements` are intended to carry out more computationally heavy tasks. They may also carry out tasks that wait for some period of time before returning, such as an `element` that calls out to a seperate database to make a classificiation.
+
+The router is laid out in a pull fashion, where the asynchronous `elements` drive the synchronous `elements` ahead of them, and the asynchronous elements are polled by the runtime.  The last element in the chain, generally a `to_device element` that communicates with the networking stack, drives much of the router by trying to fetch packets from the `elements` connected to its input ports. This provides a nice feature; back-pressure. The `elements` stop processing packets when they have nowhere to put them, since most `elements` are "lazy" and do not attempt to fetch new packets unless asked by the `element` connected to their output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,11 @@ mod utils;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{ElementLink, Element, AsyncElement};
-    use crate::utils::{LinearIntervalGenerator, ExhaustiveConsumer};
+    use crate::api::{ElementLink, Element, AsyncElementLink, AsyncElement};
+    use crate::utils::{LinearIntervalGenerator, ExhaustiveDrain, ForeverDrain};
     use core::time;
-    use futures::Stream;
+    use futures::stream::iter_ok;
+    use futures::future::lazy;
 
     struct TrivialElement {
         id: i32
@@ -23,8 +24,8 @@ mod tests {
         type Output = i32;
 
         fn process(&mut self, packet: Self::Input) -> Self::Output {
-            println!("Got packet {} in core {}", packet, self.id);
-            packet + 1
+            println!("Got packet {} in element {}", packet, self.id);
+            packet
         }
     }
 
@@ -40,8 +41,95 @@ mod tests {
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
 
-        let consumer = ExhaustiveConsumer::new(Box::new(elem2_link));
+        let consumer = ExhaustiveDrain::new(1, Box::new(elem2_link));
 
         tokio::run(consumer);
+    }
+
+
+    struct AsyncTrivialElement {
+        id: i32
+    }
+
+    impl AsyncElement for AsyncTrivialElement {
+        type Input = i32;
+        type Output = i32;
+
+        fn process(&mut self, packet: Self::Input) -> Self::Output {
+            println!("AsyncElement #{} got packet {}", self.id, packet);
+            packet
+        }
+    }
+
+
+    #[test]
+    fn one_async_element_no_waiting() {
+        let default_channel_size = 10;
+        let packet_generator = iter_ok::<_, ()>(0..20);
+
+        let elem0 = AsyncTrivialElement { id: 0 };
+
+        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
+
+        let elem0_drain = ForeverDrain::new(0, Box::new(elem0_link.frontend));
+        let elem0_consumer = ForeverDrain::new(1, Box::new(elem0_link.backend));
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem0_drain);
+            tokio::spawn(elem0_consumer);
+            Ok(())
+        }));
+    }
+
+    #[test]
+    fn two_async_elements_no_waiting() {
+        let default_channel_size = 10;
+        let packet_generator = iter_ok::<_, ()>(0..20);
+
+        let elem0 = AsyncTrivialElement { id: 0 };
+        let elem1 = AsyncTrivialElement { id: 1 };
+
+        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.backend), elem1, default_channel_size);
+
+        let elem0_drain = ForeverDrain::new(0, Box::new(elem0_link.frontend));
+        let elem1_drain = ForeverDrain::new(1, Box::new(elem1_link.frontend));
+
+        let elem1_consumer = ForeverDrain::new(1, Box::new(elem1_link.backend));
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem0_drain);
+            tokio::spawn(elem1_drain);
+            tokio::spawn(elem1_consumer);
+            Ok(())
+        }));
+    }
+
+    #[test]
+    fn series_sync_and_async_no_waiting() {
+        let default_channel_size = 10;
+        let packet_generator = iter_ok::<_, ()>(0..20);
+
+        let elem0 = TrivialElement { id: 0 };
+        let elem1 = AsyncTrivialElement { id: 1 };
+        let elem2 = TrivialElement { id: 2 };
+        let elem3 = AsyncTrivialElement { id: 3 };
+
+        let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
+        let elem2_link = ElementLink::new(Box::new(elem1_link.backend), elem2);
+        let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
+
+        let elem1_drain = ForeverDrain::new(0, Box::new(elem1_link.frontend));
+        let elem3_drain = ForeverDrain::new(1, Box::new(elem3_link.frontend));
+
+        let elem3_consumer = ForeverDrain::new(1, Box::new(elem3_link.backend));
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem1_drain);
+            tokio::spawn(elem3_drain); 
+            tokio::spawn(elem3_consumer);
+            Ok(())
+        }));
     }
 }


### PR DESCRIPTION
This is a rather large pull request. It creates a basic Async Element that can be strung together with Sync elements to for a basic serial chain of computation.  See the commit message and it's implementation for more.  It is still a bit rough, and I expect there to be further changes when we add support for reactors to the elements. But this is a good start.  I also included some changes to the Readme, again it is a little rough, but I wanted to get some foundations laid down. 