### PR TITLE
Impl Future for AsyncElementLink.frontend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ mod tests {
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
 
-        let elem0_drain = ExhaustiveDrain::new(0, Box::new(elem0_link.frontend));
-        let elem0_consumer = ExhaustiveDrain::new(1, Box::new(elem0_link.backend));
+        let elem0_drain = elem0_link.frontend;
+        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -97,10 +97,10 @@ mod tests {
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link.backend), elem1, default_channel_size);
 
-        let elem0_drain = ExhaustiveDrain::new(0, Box::new(elem0_link.frontend));
-        let elem1_drain = ExhaustiveDrain::new(1, Box::new(elem1_link.frontend));
+        let elem0_drain = elem0_link.frontend;
+        let elem1_drain = elem1_link.frontend;
 
-        let elem1_consumer = ExhaustiveDrain::new(1, Box::new(elem1_link.backend));
+        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -125,10 +125,10 @@ mod tests {
         let elem2_link = ElementLink::new(Box::new(elem1_link.backend), elem2);
         let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
 
-        let elem1_drain = ExhaustiveDrain::new(0, Box::new(elem1_link.frontend));
-        let elem3_drain = ExhaustiveDrain::new(1, Box::new(elem3_link.frontend));
+        let elem1_drain = elem1_link.frontend;
+        let elem3_drain = elem3_link.frontend;
 
-        let elem3_consumer = ExhaustiveDrain::new(2, Box::new(elem3_link.backend));
+        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem1_drain);
@@ -147,8 +147,8 @@ mod tests {
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
 
-        let elem0_drain = ExhaustiveDrain::new(0, Box::new(elem0_link.frontend));
-        let elem0_consumer = ExhaustiveDrain::new(1, Box::new(elem0_link.backend));
+        let elem0_drain = elem0_link.frontend;
+        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -168,10 +168,10 @@ mod tests {
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link.backend), elem1, default_channel_size);
 
-        let elem0_drain = ExhaustiveDrain::new(0, Box::new(elem0_link.frontend));
-        let elem1_drain = ExhaustiveDrain::new(1, Box::new(elem1_link.frontend));
+        let elem0_drain = elem0_link.frontend;
+        let elem1_drain = elem1_link.frontend;
 
-        let elem1_consumer = ExhaustiveDrain::new(1, Box::new(elem1_link.backend));
+        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -196,10 +196,10 @@ mod tests {
         let elem2_link = ElementLink::new(Box::new(elem1_link.backend), elem2);
         let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
 
-        let elem1_drain = ExhaustiveDrain::new(0, Box::new(elem1_link.frontend));
-        let elem3_drain = ExhaustiveDrain::new(1, Box::new(elem3_link.frontend));
+        let elem1_drain = elem1_link.frontend;
+        let elem3_drain = elem3_link.frontend;
 
-        let elem3_consumer = ExhaustiveDrain::new(2, Box::new(elem3_link.backend));
+        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.backend));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem1_drain);


### PR DESCRIPTION
Previously we implemented Stream for both the frontend and backend
portions of the AsyncElementLink. This makes some intuitive sense,
since a Stream is meant to stand for a continuous stream of futures,
which represents the sequence of packets being processed by an
element fairly well. However, Tokio's executor needs handles to Futures
rather than to Streams; we had to place a shim, such as the
ExhaustiveDrain utility element, in front of each stream before they are
provided to the runtime. In order to simplify the syntax, and reduce the
complexity of our API, I implemented Future for the frontend, so that
the frontend can be handed to the runtime directly.

In this implementation of Future, it never returns Async::Ready until
the element is ready to be torn down. An Element's frontend will continue
to process packets off its input stream in a loop until it can no longer
do work, in which case it will return Async::NotReady.

Note that processing logic has not actually changed, since this was the
functionality caused by placing the frontend stream into the
ExhaustiveDrain utility element.

Relevant tests were also adjusted, all tests pass after adjustment.