### PR TITLE
Convert AsyncElement to be truly asynchronous through proper use of task.notify() 

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -66,79 +66,115 @@ pub trait AsyncElement {
     fn process(&mut self, packet: Self::Input) -> Self::Output;
 }
 
-pub struct AsyncElementFrontend<E: AsyncElement> {
-    input_stream: ElementStream<E::Input>,
-    channel: Sender<E::Output>,
-    element: E
-}
-
-pub struct AsyncElementBackend<E: AsyncElement> {
-    channel: Receiver<E::Output>
-}
-
+/// The AsyncElementLink is a wrapper to create and contain both sides of the
+/// link, the consumer, which intakes and processes packets, and the provider,
+/// which provides an interface where the next element retrieves the output
+/// packet.
 pub struct AsyncElementLink< E: AsyncElement> {
-    pub frontend: AsyncElementFrontend<E>,
-    pub backend: AsyncElementBackend<E>
-}
-
-impl<E: AsyncElement> AsyncElementFrontend<E> {
-    fn new(input_stream: ElementStream<E::Input>, channel: Sender<E::Output>, element: E) -> Self {
-        AsyncElementFrontend {
-            input_stream,
-            channel,
-            element
-        }
-    }
-}
-
-impl<E: AsyncElement> AsyncElementBackend<E> {
-    fn new(channel: Receiver<E::Output>) -> Self {
-        AsyncElementBackend {
-            channel
-        }
-    }
+    pub consumer: AsyncElementConsumer<E>,
+    pub provider: AsyncElementProvider<E>
 }
 
 impl<E: AsyncElement> AsyncElementLink<E> {
     pub fn new(input_stream: ElementStream<E::Input>, element: E, queue_capacity: usize) -> Self {
-        let (sender, receiver) = bounded::<E::Output>(queue_capacity); 
+
+        let (to_provider, from_consumer) = bounded::<Option<E::Output>>(queue_capacity);
+        let (await_provider, wake_provider) = bounded::<task::Task>(1);
+        let (await_consumer, wake_consumer) = bounded::<task::Task>(1);
+
         AsyncElementLink {
-            frontend: AsyncElementFrontend::new(input_stream, sender, element),
-            backend: AsyncElementBackend::new(receiver)
+            consumer: AsyncElementConsumer::new(input_stream, to_provider, element, await_consumer, wake_provider),
+            provider: AsyncElementProvider::new(from_consumer, await_provider, wake_consumer)
         }
     }
 }
 
-/*
-*/
-impl<E: AsyncElement> Future for AsyncElementFrontend<E> {
+/// The AsyncElementConsumer is responsible for polling its input stream,
+/// processing them using the `element`s process function, and pushing the
+/// output packet onto the to_provider queue. It does work in batches, so it
+/// will continue to pull packets as long as it can make forward progess,
+/// after which it will return NotReady to sleep. This is handed to, and is
+/// polled by the runtime.
+pub struct AsyncElementConsumer<E: AsyncElement> {
+    input_stream: ElementStream<E::Input>,
+    to_provider: Sender<Option<E::Output>>,
+    element: E,
+    await_provider: Sender<task::Task>,
+    wake_provider: Receiver<task::Task>
+}
+
+impl<E: AsyncElement> AsyncElementConsumer<E> {
+    fn new(
+        input_stream: ElementStream<E::Input>, 
+        to_provider: Sender<Option<E::Output>>, 
+        element: E,
+        await_provider: Sender<task::Task>,
+        wake_provider: Receiver<task::Task>) 
+    -> Self {
+        AsyncElementConsumer {
+            input_stream,
+            to_provider,
+            element,
+            await_provider,
+            wake_provider
+        }
+    }
+}
+
+impl<E: AsyncElement> Drop for AsyncElementConsumer<E> {
+    fn drop(&mut self) {
+        if let Err(err) = self.to_provider.try_send(None) {
+            panic!("Consumer: Drop: try_send to_provider, fail?: {:?}", err);
+        }
+        if let Ok(task) = self.wake_provider.try_recv() {
+            task.notify();
+        } 
+    }
+}
+
+impl<E: AsyncElement> Future for AsyncElementConsumer<E> {
     type Item = ();
     type Error = ();
 
-    /*
-    //Documentation
-    */
+    /// Implement Poll for Future for AsyncElementConsumer
+    /// 
+    /// Note that this function works a bit different, it continues to process
+    /// packets off it's input queue until it reaches a point where it can not
+    /// make forward progress. There are three cases:
+    /// ###
+    /// #1 The to_provider queue is full, we notify the provider that we need
+    /// awaking when there is work to do, and go to sleep.
+    /// 
+    /// #2 The input_stream returns a NotReady, we sleep, with the assumption
+    /// that whomever produced the NotReady will awaken the task in the Future.
+    /// 
+    /// #3 We get a Ready(None), in which case we push a None onto the to_provider
+    /// queue and then return Ready(()), which means we enter tear-down, since there
+    /// is no futher work to complete.
+    /// ###
+    /// By Sleep, we mean we return a NotReady to the runtime which will sleep the task.
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if self.channel.is_full() {
-            //Queue is full, immediately reschedule task.
-            task::current().notify();
-            return Ok(Async::NotReady);
-        }
-        //Pull packets off input stream unti we run out of packets
-        loop {
-            //try_ready! will bubble up the Async::NotReady if receives one
+        loop{
+            if self.to_provider.is_full() {
+                let task = task::current();
+                if let Err(_) = self.await_provider.try_send(task) {
+                    task::current().notify();
+                }
+                return Ok(Async::NotReady)
+            }
             let input_packet_option: Option<E::Input> = try_ready!(self.input_stream.poll());
+
             match input_packet_option {
                 None => {
-                    println!("packet option was none");
-                    return Ok(Async::Ready(()));
+                    return Ok(Async::Ready(()))
                 }
                 Some(input_packet) => {
                     let output_packet: E::Output = self.element.process(input_packet);
-                    //Assume that channel cannot be filled since we checked
-                    if let Err(err) = self.channel.send(output_packet) {
-                        println!("{:?}", err);
-                        return Ok(Async::Ready(()));
+                    if let Err(err) = self.to_provider.send(Some(output_packet)) {
+                        panic!("Error in to_provider sender, have nowhere to put packet: {:?}", err);
+                    }
+                    if let Ok(task) = self.wake_provider.try_recv() {
+                        task.notify();
                     }
                 },
             }
@@ -146,21 +182,75 @@ impl<E: AsyncElement> Future for AsyncElementFrontend<E> {
     }
 }
 
-impl<E: AsyncElement> Stream for AsyncElementBackend<E> {
+/// The Provider side of the AsyncElement is responsible to converting the
+/// output queue of processed packets, which is a crossbeam channel, to a 
+/// Stream that can be polled for packets. It ends up being owned by the 
+/// element which is polling for packets. 
+pub struct AsyncElementProvider<E: AsyncElement> {
+    from_consumer: Receiver<Option<E::Output>>,
+    await_consumer: Sender<task::Task>,
+    wake_consumer: Receiver<task::Task>
+}
+
+impl<E: AsyncElement> AsyncElementProvider<E> {
+    fn new(from_consumer: Receiver<Option<E::Output>>, await_consumer: Sender<task::Task>, wake_consumer: Receiver<task::Task>) -> Self {
+        AsyncElementProvider {
+            from_consumer,
+            await_consumer,
+            wake_consumer
+        }
+    }
+}
+
+impl<E: AsyncElement> Drop for AsyncElementProvider<E> {
+    fn drop(&mut self) {
+        if let Ok(task) = self.wake_consumer.try_recv() {
+            task.notify();
+        }
+    }
+}
+
+impl<E: AsyncElement> Stream for AsyncElementProvider<E> {
     type Item = E::Output;
     type Error = ();
 
+    ///Implement Poll for Stream for AsyncElementProvider
+    /// 
+    /// This function, tries to retrieve a packet off the `from_consumer`
+    /// channel, there are four cases: 
+    /// ###
+    /// #1 Ok(Some(Packet)): Got a packet.if the consumer needs (likely due to 
+    /// an until now full channel) to be awoken, wake them. Return the Async::Ready(Option(Packet))
+    /// 
+    /// #2 Ok(None): this means that the consumer is in tear-down, and we
+    /// will no longer be receivig packets. Return Async::Ready(None) to forward propagate teardown
+    /// 
+    /// #3 Err(TryRecvError::Empty): Packet queue is empty, await the consumer to awaken us with more
+    /// work, and return Async::NotReady to signal to runtime to sleep this task.
+    /// 
+    /// #4 Err(TryRecvError::Disconnected): Consumer is in teardown and has dropped its side of the
+    /// from_consumer channel; we will no longer receive packets. Return Async::Ready(None) to forward
+    /// propagate teardown.
+    /// ###
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        // Check associated channel receiver to see if we have any packets available to send along
-        match self.channel.try_recv() {
-            Ok(packet) => Ok(Async::Ready(Some(packet))),
+        match self.from_consumer.try_recv() {
+            Ok(Some(packet)) => {
+                if let Ok(task) = self.wake_consumer.try_recv() {
+                        task.notify();
+                }
+                Ok(Async::Ready(Some(packet)))
+            },
+            Ok(None) => {
+                Ok(Async::Ready(None))
+            },
             Err(TryRecvError::Empty) => {
-                //Nothing in queue, immediately tell Tokio to reschedule this task.
-                task::current().notify();
+                let task = task::current();
+                if let Err(_) = self.await_consumer.try_send(task) {
+                    task::current().notify();
+                }
                 Ok(Async::NotReady)
-                },
+            },
             Err(TryRecvError::Disconnected) => {
-                println!("receiving channel disconnected");
                 Ok(Async::Ready(None))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,14 +70,14 @@ mod tests {
     #[test]
     fn one_async_element_immediate_yield() {
         let default_channel_size = 10;
-        let packet_generator = iter_ok::<_, ()>(0..20);
+        let packet_generator = iter_ok::<_, ()>(0..21);
 
         let elem0 = AsyncTrivialElement { id: 0 };
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
 
-        let elem0_drain = elem0_link.frontend;
-        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.backend));
+        let elem0_drain = elem0_link.consumer;
+        let elem0_consumer = ExhaustiveDrain::new(1, Box::new(elem0_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -95,12 +95,12 @@ mod tests {
         let elem1 = AsyncTrivialElement { id: 1 };
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.backend), elem1, default_channel_size);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.provider), elem1, default_channel_size);
 
-        let elem0_drain = elem0_link.frontend;
-        let elem1_drain = elem1_link.frontend;
+        let elem0_drain = elem0_link.consumer;
+        let elem1_drain = elem1_link.consumer;
 
-        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.backend));
+        let elem1_consumer = ExhaustiveDrain::new(1, Box::new(elem1_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -122,13 +122,13 @@ mod tests {
 
         let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
-        let elem2_link = ElementLink::new(Box::new(elem1_link.backend), elem2);
+        let elem2_link = ElementLink::new(Box::new(elem1_link.provider), elem2);
         let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
 
-        let elem1_drain = elem1_link.frontend;
-        let elem3_drain = elem3_link.frontend;
+        let elem1_drain = elem1_link.consumer;
+        let elem3_drain = elem3_link.consumer;
 
-        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.backend));
+        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem1_drain);
@@ -147,8 +147,8 @@ mod tests {
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
 
-        let elem0_drain = elem0_link.frontend;
-        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.backend));
+        let elem0_drain = elem0_link.consumer;
+        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -166,12 +166,12 @@ mod tests {
         let elem1 = AsyncTrivialElement { id: 1 };
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.backend), elem1, default_channel_size);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.provider), elem1, default_channel_size);
 
-        let elem0_drain = elem0_link.frontend;
-        let elem1_drain = elem1_link.frontend;
+        let elem0_drain = elem0_link.consumer;
+        let elem1_drain = elem1_link.consumer;
 
-        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.backend));
+        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem0_drain);
@@ -193,13 +193,13 @@ mod tests {
 
         let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
-        let elem2_link = ElementLink::new(Box::new(elem1_link.backend), elem2);
+        let elem2_link = ElementLink::new(Box::new(elem1_link.provider), elem2);
         let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
 
-        let elem1_drain = elem1_link.frontend;
-        let elem3_drain = elem3_link.frontend;
+        let elem1_drain = elem1_link.consumer;
+        let elem3_drain = elem3_link.consumer;
 
-        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.backend));
+        let elem3_consumer = ExhaustiveDrain::new(2, Box::new(elem3_link.provider));
 
         tokio::run(lazy (|| {
             tokio::spawn(elem1_drain);


### PR DESCRIPTION
This is a large commit, becuase quite a few things changed in order
to make this change work. In the future, I expect the commits to get
shorter as the codebase matures.

In this commit we:

Rename the Frontend and Backend members of AsyncElementLink to Consumer
and Provider, respectfully. This improves the clarity, and also avoids
the use of some fairly overloaded terms. The Consumer is responsible for
consuming the packets off the input stream to the AsyncElement and
processing them. The Provider, provides the output packets, which are
queued up in an internal channel, to a caller via its implementation of
`Stream`. Think of the Consumer as the input interface, and the Provider
as the output interface.

We now start to return Async::NotReady when we are not able to make forward
progress. At this point we are truly taking advantage of Tokio's runtime,
and our AsyncElement can now be run in parallel, concurrently,
cross-thread, cross-core, you name it. It is done in an efficient manner
so that we are yielding compute resources when no more work can be done.

This is enabled by passing `Task` handles from the Producer to the
Consumer, and vis versa, when either is unable to make progress. When
the other side has cleared whatever blocker caused the sleep in the
first place, it will awaken the slept `Task`.

There is some additional work done to ensure that during shutdown,
tasks are not left to sleep forever. This is best explained by the
comments surrounding the `Drop` and `Poll` function implementations.