### PR TITLE
Add new test type, collected yield. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ mod utils;
 mod tests {
     use super::*;
     use crate::api::{ElementLink, Element, AsyncElementLink, AsyncElement};
-    use crate::utils::test::packet_generators::{ immediate_stream, LinearIntervalGenerator };
-    use crate::utils::test::packet_collectors::ExhaustiveDrain;
+    use crate::utils::test::packet_generators::{immediate_stream, LinearIntervalGenerator, PacketIntervalGenerator};
+    use crate::utils::test::packet_collectors::{ExhaustiveDrain, ExhaustiveCollector};
     use core::time;
 
     use futures::future::lazy;
@@ -52,6 +52,26 @@ mod tests {
         tokio::run(consumer);
     }
 
+    #[test]
+    fn one_sync_element_collected_yield() {
+        let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7];
+        let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
+
+        let elem1 = IdentityElement { id: 0 };
+        let elem2 = IdentityElement { id: 1 };
+
+        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+
+        let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
+        let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
+
+        let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);
+
+        tokio::run(consumer);
+
+        let router_output: Vec<_> = r.iter().collect();
+        assert_eq!(router_output, packets);
+    }
 
     struct AsyncIdentityElement {
         id: i32
@@ -209,5 +229,91 @@ mod tests {
             tokio::spawn(elem3_consumer);
             Ok(())
         }));
+    }
+
+    #[test]
+    fn one_async_element_collected_yield() {
+        let default_channel_size = 10;
+        let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7];
+        let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
+
+        let elem0 = AsyncIdentityElement { id: 0 };
+
+        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
+
+        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let elem0_drain = elem0_link.consumer;
+        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.provider), s);
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem0_drain);
+            tokio::spawn(elem0_collector);
+            Ok(())
+        }));
+
+        let router_output: Vec<_> = r.iter().collect();
+        assert_eq!(router_output, packets);
+    }
+
+    #[test]
+    fn two_async_elements_collected_yield() {
+        let default_channel_size = 10;
+        let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7];
+        let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
+
+        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem1 = AsyncIdentityElement { id: 1 };
+
+        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.provider), elem1, default_channel_size);
+
+        let elem0_drain = elem0_link.consumer;
+        let elem1_drain = elem1_link.consumer;
+
+        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let elem1_collector = ExhaustiveCollector::new(0, Box::new(elem1_link.provider), s);
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem0_drain);
+            tokio::spawn(elem1_drain);
+            tokio::spawn(elem1_collector);
+            Ok(())
+        }));
+
+        let router_output: Vec<_> = r.iter().collect();
+        assert_eq!(router_output, packets);
+    }
+
+    #[test]
+    fn series_sync_and_async_collected_yield() {
+        let default_channel_size = 10;
+        let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7];
+        let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
+
+        let elem0 = IdentityElement { id: 0 };
+        let elem1 = AsyncIdentityElement { id: 1 };
+        let elem2 = IdentityElement { id: 2 };
+        let elem3 = AsyncIdentityElement { id: 3 };
+
+        let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
+        let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
+        let elem2_link = ElementLink::new(Box::new(elem1_link.provider), elem2);
+        let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
+
+        let elem1_drain = elem1_link.consumer;
+        let elem3_drain = elem3_link.consumer;
+
+        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let elem3_collector = ExhaustiveCollector::new(0, Box::new(elem3_link.provider), s);
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem1_drain);
+            tokio::spawn(elem3_drain); 
+            tokio::spawn(elem3_collector);
+            Ok(())
+        }));
+
+        let router_output: Vec<_> = r.iter().collect();
+        assert_eq!(router_output, packets);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod tests {
     use crate::utils::test::packet_generators::{immediate_stream, LinearIntervalGenerator, PacketIntervalGenerator};
     use crate::utils::test::packet_collectors::{ExhaustiveDrain, ExhaustiveCollector};
     use core::time;
+    use crossbeam::crossbeam_channel;
 
     use futures::future::lazy;
 
@@ -26,7 +27,6 @@ mod tests {
         type Output = i32;
 
         fn process(&mut self, packet: Self::Input) -> Self::Output {
-            //println!("Got packet {} in element {}", packet, self.id);
             packet
         }
     }
@@ -82,7 +82,6 @@ mod tests {
         type Output = i32;
 
         fn process(&mut self, packet: Self::Input) -> Self::Output {
-            //println!("AsyncElement #{} got packet {}", self.id, packet);
             packet
         }
     }
@@ -241,7 +240,7 @@ mod tests {
 
         let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
 
-        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let (s, r) = crossbeam_channel::unbounded();
         let elem0_drain = elem0_link.consumer;
         let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.provider), s);
 
@@ -270,7 +269,7 @@ mod tests {
         let elem0_drain = elem0_link.consumer;
         let elem1_drain = elem1_link.consumer;
 
-        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let (s, r) = crossbeam_channel::unbounded();
         let elem1_collector = ExhaustiveCollector::new(0, Box::new(elem1_link.provider), s);
 
         tokio::run(lazy (|| {
@@ -303,7 +302,7 @@ mod tests {
         let elem1_drain = elem1_link.consumer;
         let elem3_drain = elem3_link.consumer;
 
-        let (s, r) = crossbeam::crossbeam_channel::unbounded();
+        let (s, r) = crossbeam_channel::unbounded();
         let elem3_collector = ExhaustiveCollector::new(0, Box::new(elem3_link.provider), s);
 
         tokio::run(lazy (|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod tests {
 
     use futures::future::lazy;
 
+    #[allow(dead_code)]
     struct IdentityElement {
         id: i32
     }
@@ -25,7 +26,7 @@ mod tests {
         type Output = i32;
 
         fn process(&mut self, packet: Self::Input) -> Self::Output {
-            println!("Got packet {} in element {}", packet, self.id);
+            //println!("Got packet {} in element {}", packet, self.id);
             packet
         }
     }
@@ -41,8 +42,6 @@ mod tests {
 
         let elem1 = IdentityElement { id: 0 };
         let elem2 = IdentityElement { id: 1 };
-
-        // core_elem1 to! core_elem2
 
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
@@ -73,6 +72,7 @@ mod tests {
         assert_eq!(router_output, packets);
     }
 
+    #[allow(dead_code)]
     struct AsyncIdentityElement {
         id: i32
     }
@@ -82,7 +82,7 @@ mod tests {
         type Output = i32;
 
         fn process(&mut self, packet: Self::Input) -> Self::Output {
-            println!("AsyncElement #{} got packet {}", self.id, packet);
+            //println!("AsyncElement #{} got packet {}", self.id, packet);
             packet
         }
     }

--- a/src/utils/test/packet_collectors.rs
+++ b/src/utils/test/packet_collectors.rs
@@ -23,11 +23,11 @@ impl<T: Debug> Future for ExhaustiveDrain<T> {
 
         loop {
             match try_ready!(self.stream.poll()) {
-                Some(value) => {
-                    println!("Drain #{} received packet: {:?}", self.id, value);
+                Some(_value) => {
+                    //println!("Drain #{} received packet: {:?}", self.id, value);
                 },
                 None => {
-                    println!("Drain #{} received none. End of packet stream", self.id);
+                    //println!("Drain #{} received none. End of packet stream", self.id);
                     return Ok(Async::Ready(()))
                 }
             }
@@ -63,7 +63,7 @@ impl<T: Debug> Future for ExhaustiveCollector<T> {
                     };
                 },
                 None => {
-                    println!("Collector #{} received none. End of packet stream", self.id);
+                    //println!("Collector #{} received none. End of packet stream", self.id);
                     return Ok(Async::Ready(()))
                 }
             }

--- a/src/utils/test/packet_collectors.rs
+++ b/src/utils/test/packet_collectors.rs
@@ -1,6 +1,7 @@
 use crate::api::ElementStream;
 use futures::{Async, Poll, Future};
 use std::fmt::Debug;
+use crossbeam::crossbeam_channel;
 
 pub struct ExhaustiveDrain<T: Debug> {
     id: usize,
@@ -27,6 +28,42 @@ impl<T: Debug> Future for ExhaustiveDrain<T> {
                 },
                 None => {
                     println!("Drain #{} received none. End of packet stream", self.id);
+                    return Ok(Async::Ready(()))
+                }
+            }
+        }
+    }
+}
+
+/// Exhaustive Collector works like Exhaustive Drain in that it continously polls for packets until it
+/// receives a None, but it also will write that value out to the provided channel, so that the packet
+/// may be compared in a test.
+pub struct ExhaustiveCollector<T: Debug> {
+    id: usize,
+    stream: ElementStream<T>,
+    packet_dump: crossbeam_channel::Sender<T>
+}
+
+impl<T: Debug> ExhaustiveCollector<T> {
+    pub fn new(id: usize, stream: ElementStream<T>, packet_dump: crossbeam_channel::Sender<T>) -> Self {
+        ExhaustiveCollector { id, stream, packet_dump }
+    }
+}
+
+impl<T: Debug> Future for ExhaustiveCollector<T> {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            match try_ready!(self.stream.poll()) {
+                Some(value) => {
+                    if let Err(err) = self.packet_dump.try_send(value) {
+                        println!("Exhaustive Collector: Error sending to packet dump: {:?}", err);
+                    };
+                },
+                None => {
+                    println!("Collector #{} received none. End of packet stream", self.id);
                     return Ok(Async::Ready(()))
                 }
             }


### PR DESCRIPTION
The commit messages should speak for themselves. But collected yield is a test where we actually collect the output from the router so that we can compare it to the expected output and produce a pass/fail case that is not determined solely by whether the runtime returns or not.  I imagine that at some point almost all of our tests will follow the collected yield model, but this is a good first step.  To support this I created a new generator and collector. I think they are suitably generic for now, we may need some more features down the road, but I don't know what that might be at this juncture. 

I also include a commit that reduces the verbosity of our test pieces, I figure we should really only be printing output on a test failure, so that the test output is not impossible to read. This might be contentious though so I welcome feedback on this move.