### PR TITLE
Async Element Cleanup: {Add overseer, better tests}

### DIFF
--- a/src/api/async_element.rs
+++ b/src/api/async_element.rs
@@ -207,8 +207,8 @@ impl<E: AsyncElement> Stream for AsyncElementProvider<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test::packet_generators::{LinearIntervalGenerator, PacketIntervalGenerator, immediate_stream};
-    use crate::utils::test::packet_collectors::{ExhaustiveDrain, ExhaustiveCollector};
+    use crate::utils::test::packet_generators::{PacketIntervalGenerator, immediate_stream};
+    use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::api::element::{Element, ElementLink};
     use core::time;
     use futures::future::lazy;
@@ -241,152 +241,8 @@ mod tests {
         }
     }
 
-
     #[test]
-    fn one_async_element_immediate_yield() {
-        let default_channel_size = 10;
-        let packet_generator = immediate_stream(0..=20);
-
-
-        let elem0 = AsyncIdentityElement { id: 0 };
-
-        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-
-        let elem0_drain = elem0_link.consumer;
-        let elem0_consumer = ExhaustiveDrain::new(1, Box::new(elem0_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_consumer);
-            Ok(())
-        }));
-    }
-
-    #[test]
-    fn two_async_elements_immediate_yield() {
-        let default_channel_size = 10;
-        let packet_generator = immediate_stream(0..=20);
-
-        let elem0 = AsyncIdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
-
-        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.provider), elem1, default_channel_size);
-
-        let elem0_drain = elem0_link.consumer;
-        let elem1_drain = elem1_link.consumer;
-
-        let elem1_consumer = ExhaustiveDrain::new(1, Box::new(elem1_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem1_consumer);
-            Ok(())
-        }));
-    }
-
-    #[test]
-    fn series_sync_and_async_immediate_yield() {
-        let default_channel_size = 10;
-        let packet_generator = immediate_stream(0..=20);
-
-        let elem0 = IdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
-        let elem2 = IdentityElement { id: 2 };
-        let elem3 = AsyncIdentityElement { id: 3 };
-
-        let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
-        let elem2_link = ElementLink::new(Box::new(elem1_link.provider), elem2);
-        let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
-
-        let elem1_drain = elem1_link.consumer;
-        let elem3_drain = elem3_link.consumer;
-
-        let elem3_consumer = ExhaustiveDrain::new(0, Box::new(elem3_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem3_drain); 
-            tokio::spawn(elem3_consumer);
-            Ok(())
-        }));
-    }
-
-        #[test]
-    fn one_async_element_interval_yield() {
-        let default_channel_size = 10;
-        let packet_generator = LinearIntervalGenerator::new(time::Duration::from_millis(100), 20);
-
-        let elem0 = AsyncIdentityElement { id: 0 };
-
-        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-
-        let elem0_drain = elem0_link.consumer;
-        let elem0_consumer = ExhaustiveDrain::new(0, Box::new(elem0_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_consumer);
-            Ok(())
-        }));
-    }
-
-    #[test]
-    fn two_async_elements_interval_yield() {
-        let default_channel_size = 10;
-        let packet_generator = LinearIntervalGenerator::new(time::Duration::from_millis(100), 20);
-
-        let elem0 = AsyncIdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
-
-        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link.provider), elem1, default_channel_size);
-
-        let elem0_drain = elem0_link.consumer;
-        let elem1_drain = elem1_link.consumer;
-
-        let elem1_consumer = ExhaustiveDrain::new(0, Box::new(elem1_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem1_consumer);
-            Ok(())
-        }));
-    }
-
-    #[test]
-    fn series_sync_and_async_interval_yield() {
-        let default_channel_size = 10;
-        let packet_generator = LinearIntervalGenerator::new(time::Duration::from_millis(100), 20);
-
-        let elem0 = IdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
-        let elem2 = IdentityElement { id: 2 };
-        let elem3 = AsyncIdentityElement { id: 3 };
-
-        let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
-        let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
-        let elem2_link = ElementLink::new(Box::new(elem1_link.provider), elem2);
-        let elem3_link = AsyncElementLink::new(Box::new(elem2_link), elem3, default_channel_size);
-
-        let elem1_drain = elem1_link.consumer;
-        let elem3_drain = elem3_link.consumer;
-
-        let elem3_consumer = ExhaustiveDrain::new(2, Box::new(elem3_link.provider));
-
-        tokio::run(lazy (|| {
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem3_drain); 
-            tokio::spawn(elem3_consumer);
-            Ok(())
-        }));
-    }
-
-    #[test]
-    fn one_async_element_collected_yield() {
+    fn one_async_element() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8 , 9];
         let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
@@ -410,7 +266,30 @@ mod tests {
     }
 
     #[test]
-    fn two_async_elements_collected_yield() {
+    fn one_async_element_long_stream() {
+        let default_channel_size = 10;
+        let packet_generator = immediate_stream(0..=2000);
+
+        let elem0 = AsyncIdentityElement { id: 0 };
+
+        let elem0_link = AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
+
+        let (s, r) = crossbeam_channel::unbounded();
+        let elem0_drain = elem0_link.consumer;
+        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.provider), s);
+
+        tokio::run(lazy (|| {
+            tokio::spawn(elem0_drain);
+            tokio::spawn(elem0_collector);
+            Ok(())
+        }));
+
+        let router_output: Vec<_> = r.iter().collect();
+        assert_eq!(router_output.len(), 2001);
+    }
+
+    #[test]
+    fn two_async_elements() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8 ,9];
         let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());
@@ -439,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn series_sync_and_async_collected_yield() {
+    fn series_sync_and_async() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(time::Duration::from_millis(100), packets.clone().into_iter());


### PR DESCRIPTION
This PR does two things, it solves the known race condition with AsyncElement, by adding the Overseer to the link. It also cleans up the tests associated with AsyncElement, using better names and removing some extraneous ones. 