### PR TITLE
api: pub use to reduce namespace clutter

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,15 @@
 use futures::Stream;
 
-pub mod element;
-pub mod async_element;
-pub mod classify_element;
-pub mod join_element;
+mod element;
+pub use self::element::*;
+
+mod async_element;
+pub use self::async_element::*;
+
+mod classify_element;
+pub use self::classify_element::*;
+
+mod join_element;
+pub use self::join_element::*;
 
 pub type ElementStream<Input> = Box<dyn Stream<Item = Input, Error = ()> + Send>;


### PR DESCRIPTION
It's nice for us to group parts of the API into different files, but
this means that the namespaces are getting overly verbose. We can
declare our subfiles with pub use to export them into the main api
namespace and make it easier to work with.