### PR TITLE
api: make tests use immediate_stream

### DIFF
--- a/src/api/async_element.rs
+++ b/src/api/async_element.rs
@@ -395,7 +395,7 @@ mod tests {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
+            time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
 
@@ -407,12 +407,10 @@ mod tests {
         let (s, r) = crossbeam_channel::unbounded();
         let elem0_drain = elem0_link.consumer;
         let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.provider), s);
-        let elem0_overseer = elem0_link.overseer;
 
         tokio::run(lazy(|| {
             tokio::spawn(elem0_drain);
             tokio::spawn(elem0_collector);
-            tokio::spawn(elem0_overseer);
             Ok(())
         }));
 

--- a/src/api/classify_element.rs
+++ b/src/api/classify_element.rs
@@ -396,7 +396,7 @@ mod tests {
         let number_branches = 2;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
+            time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
 
@@ -410,7 +410,6 @@ mod tests {
         );
 
         let elem0_drain = elem0_link.consumer;
-        let elem0_overseer = elem0_link.overseer;
 
         // Ordering is important since we are popping.
         let (s1, elem0_port1_collector_output) = crossbeam_channel::unbounded();
@@ -425,7 +424,6 @@ mod tests {
             tokio::spawn(elem0_drain);
             tokio::spawn(elem0_port0_collector);
             tokio::spawn(elem0_port1_collector);
-            tokio::spawn(elem0_overseer);
             Ok(())
         }));
 

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -102,7 +102,7 @@ mod tests {
     fn one_sync_element_wait_between_packets() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
+            time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
 

--- a/src/api/join_element.rs
+++ b/src/api/join_element.rs
@@ -432,11 +432,11 @@ mod tests {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9, 11];
         let packet_generator0 = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
+            time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
         let packet_generator1 = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
+            time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
 


### PR DESCRIPTION
Most tests should use immediate_stream as the default packet_generator
to ensure that they are _speedy_.

This change doesn't prune`LinearIntervalGenerator` or `ExhaustiveDrain` since they may still be useful.

fixes #31