### PR TITLE
IdentityElement: move duplicated element to test

### DIFF
--- a/src/api/async_element.rs
+++ b/src/api/async_element.rs
@@ -246,39 +246,12 @@ impl<E: AsyncElement> Stream for AsyncElementProvider<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::element::{Element, ElementLink};
+    use crate::api::element::ElementLink;
+    use crate::utils::test::identity_elements::{AsyncIdentityElement, IdentityElement};
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
     use futures::future::lazy;
-
-    #[allow(dead_code)]
-    struct IdentityElement {
-        id: i32,
-    }
-
-    impl Element for IdentityElement {
-        type Input = i32;
-        type Output = i32;
-
-        fn process(&mut self, packet: Self::Input) -> Self::Output {
-            packet
-        }
-    }
-
-    #[allow(dead_code)]
-    struct AsyncIdentityElement {
-        id: i32,
-    }
-
-    impl AsyncElement for AsyncIdentityElement {
-        type Input = i32;
-        type Output = i32;
-
-        fn process(&mut self, packet: Self::Input) -> Self::Output {
-            packet
-        }
-    }
 
     #[test]
     fn one_async_element() {
@@ -286,7 +259,7 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -310,7 +283,7 @@ mod tests {
         let default_channel_size = 10;
         let packet_generator = immediate_stream(0..2000);
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -333,10 +306,10 @@ mod tests {
     #[should_panic(expected = "queue capacity must be non-zero")]
     fn one_async_element_empty_channel() {
         let default_channel_size = 0;
-        let packets = vec![];
+        let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets);
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let _elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -351,7 +324,7 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -373,10 +346,10 @@ mod tests {
     #[test]
     fn one_async_element_empty_stream() {
         let default_channel_size = 10;
-        let packets = vec![];
+        let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -401,8 +374,8 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
+        let elem0 = AsyncIdentityElement::new(0);
+        let elem1 = AsyncIdentityElement::new(1);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -432,10 +405,10 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = IdentityElement { id: 0 };
-        let elem1 = AsyncIdentityElement { id: 1 };
-        let elem2 = IdentityElement { id: 2 };
-        let elem3 = AsyncIdentityElement { id: 3 };
+        let elem0 = IdentityElement::new(0);
+        let elem1 = AsyncIdentityElement::new(1);
+        let elem2 = IdentityElement::new(2);
+        let elem3 = AsyncIdentityElement::new(3);
 
         let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
@@ -468,7 +441,7 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem0 = AsyncIdentityElement { id: 0 };
+        let elem0 = AsyncIdentityElement::new(0);
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -60,31 +60,23 @@ impl<E: Element> Stream for ElementLink<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::test::identity_elements::IdentityElement;
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
 
-    #[allow(dead_code)]
-    struct IdentityElement {
-        id: i32,
-    }
-
-    impl Element for IdentityElement {
-        type Input = i32;
-        type Output = i32;
-
-        fn process(&mut self, packet: Self::Input) -> Self::Output {
-            packet
-        }
-    }
-
+    /// One Synchronous Element, sourced with an interval yield
+    ///
+    /// This test creates one Sync element, and uses the LinearIntervalGenerator to test whether
+    /// the element responds correctly to an upstream source providing a series of valid packets,
+    /// interleaved with Async::NotReady values, finalized by a Async::Ready(None)
     #[test]
     fn one_sync_element() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem1 = IdentityElement { id: 0 };
-        let elem2 = IdentityElement { id: 1 };
+        let elem1 = IdentityElement::new(0);
+        let elem2 = IdentityElement::new(1);
 
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
@@ -106,8 +98,8 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem1 = IdentityElement { id: 0 };
-        let elem2 = IdentityElement { id: 1 };
+        let elem1 = IdentityElement::new(0);
+        let elem2 = IdentityElement::new(1);
 
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);

--- a/src/utils/test/identity_elements.rs
+++ b/src/utils/test/identity_elements.rs
@@ -1,0 +1,54 @@
+use crate::api::{AsyncElement, Element};
+use std::marker::PhantomData;
+
+/* IdentityElement
+  This is an element that passes what it has received
+*/
+pub struct IdentityElement<A: Sized> {
+    id: i32,
+    phantom: PhantomData<A>,
+}
+
+impl<A> IdentityElement<A> {
+    pub fn new(id: i32) -> IdentityElement<A> {
+        IdentityElement {
+            id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A> Element for IdentityElement<A> {
+    type Input = A;
+    type Output = A;
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        packet
+    }
+}
+
+/* AsyncIdentityElement
+  This is an async element that passes what it has received
+*/
+pub struct AsyncIdentityElement<A: Sized> {
+    id: i32,
+    phantom: PhantomData<A>,
+}
+
+impl<A> AsyncIdentityElement<A> {
+    pub fn new(id: i32) -> AsyncIdentityElement<A> {
+        AsyncIdentityElement {
+            id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A> AsyncElement for AsyncIdentityElement<A> {
+    type Input = A;
+    type Output = A;
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        packet
+    }
+}

--- a/src/utils/test/mod.rs
+++ b/src/utils/test/mod.rs
@@ -1,2 +1,3 @@
+pub mod identity_elements;
 pub mod packet_collectors;
 pub mod packet_generators;


### PR DESCRIPTION
This deduplicates IdentityElement and moves AsyncIdentityElement
with it to identity_elemts.rs. They were also made more generic
so it's not limited to i32. We may want to move these out of the
test directory if they become used outside tests.

Also removed dead_code markers

Issue #30