### PR TITLE
task_park: extract common utilities

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-use futures::{task, Stream};
+use futures::Stream;
 
 mod element;
 pub use self::element::*;
@@ -14,8 +14,4 @@ pub use self::join_element::*;
 
 pub type ElementStream<Input> = Box<dyn Stream<Item = Input, Error = ()> + Send>;
 
-enum TaskParkState {
-    Dead,
-    Empty,
-    Full(task::Task),
-}
+mod task_park;

--- a/src/api/task_park.rs
+++ b/src/api/task_park.rs
@@ -1,0 +1,50 @@
+use crossbeam::atomic::AtomicCell;
+use futures::task;
+use std::sync::Arc;
+
+/**
+The task_park module consists of different utilities needed to manage task waking for concurrent
+route-rs elements. These utilities should not be exposed via the Elements API.
+*/
+
+pub enum TaskParkState {
+    Dead,
+    Empty,
+    Full(task::Task),
+}
+
+pub fn unpark_and_notify(task_park: &Arc<AtomicCell<TaskParkState>>) {
+    match task_park.swap(TaskParkState::Empty) {
+        TaskParkState::Full(other_task) => {
+            other_task.notify();
+        }
+        TaskParkState::Empty => {}
+        // If the `task_park` died, we must retain
+        // the Dead state to prevent deadlocks on Drop.
+        TaskParkState::Dead => {
+            task_park.store(TaskParkState::Dead);
+        }
+    }
+}
+
+pub fn park_and_notify(task_park: &Arc<AtomicCell<TaskParkState>>) {
+    let current_task = task::current();
+    match task_park.swap(TaskParkState::Full(current_task)) {
+        TaskParkState::Full(other_task) => {
+            other_task.notify();
+        }
+        TaskParkState::Empty => {}
+        // If the `task_park` died, we must self notify
+        // and retain the Dead state to prevent deadlocks on Drop.
+        TaskParkState::Dead => {
+            task_park.store(TaskParkState::Dead);
+            task::current().notify();
+        }
+    }
+}
+
+pub fn die_and_notify(task_park: &Arc<AtomicCell<TaskParkState>>) {
+    if let TaskParkState::Full(other_task) = task_park.swap(TaskParkState::Dead) {
+        other_task.notify();
+    }
+}


### PR DESCRIPTION
It turns out that there are very repeatable patterns to dealing with
task-wake management in concurrent elements. Those are:

1) unpark_and_notify: "I have work to, so don't bother waking me up."
2) park_and_notify: "I don't have any work to do. Let me know when I do."
3) die_and_notify: "I'm shutting down, and I'll either let you wake me
up if you're around, or I'll self-notify if I die".

park and unpark variants will notify a task if it exists in the park as
the new state is swapped in, and will maintain the "dead" state so
die_and_notify works appropriately.

relates to #29 