### PR TITLE
Async Element: Shorten longest test with immediate stream

### DIFF
--- a/src/api/async_element.rs
+++ b/src/api/async_element.rs
@@ -285,10 +285,7 @@ mod tests {
     fn one_async_element_small_channel() {
         let default_channel_size = 1;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
-        let packet_generator = PacketIntervalGenerator::new(
-            time::Duration::from_millis(100),
-            packets.clone().into_iter(),
-        );
+        let packet_generator = immediate_stream(packets.clone());
 
         let elem0 = AsyncIdentityElement::new(0);
 


### PR DESCRIPTION
This is a small change to one of our tests that is rather long
running, at least compared to other tests. Switching to immediate
stream when we are not testing packet delay improves the speed.

Test run time reduces from 1.349s -> 0.061s

All tests now run on my build machine in ~0.3s, check my flex.