### PR TITLE
Pipeline and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,10 @@
 [workspace]
 members = [
+    # API Crates
+    # These crates can actually be used by other people and might be published to crates.io
     "route-rs-runtime",
+
+    # Example crates
+    # These crates show usage of route-rs features and should _not_ be published to crates.io
+    "examples/trivial-identity",
 ]

--- a/examples/trivial-identity/Cargo.toml
+++ b/examples/trivial-identity/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "trivial-identity"
+version = "0.1.0"
+authors = ["Sam Gruber <sam@scgruber.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+route-rs-runtime = { path = "../../route-rs-runtime" }
+tokio = "*"
+futures = "*"
+crossbeam = "*"

--- a/examples/trivial-identity/src/main.rs
+++ b/examples/trivial-identity/src/main.rs
@@ -1,0 +1,31 @@
+use crate::packets::IntegerPacket;
+use crossbeam::crossbeam_channel;
+use route_rs_runtime::pipeline::Runner;
+
+mod packets;
+mod pipeline;
+
+fn main() {
+    let (input_sender, input_receiver) = crossbeam_channel::unbounded();
+    let (output_sender, output_receiver) = crossbeam_channel::unbounded();
+
+    for n in 0..10 {
+        let in_packet = IntegerPacket { id: n };
+        match input_sender.send(in_packet.clone()) {
+            Ok(_) => println!("Sent {:?}", in_packet),
+            Err(err) => panic!("Input channel error {}", err),
+        }
+    }
+
+    drop(input_sender);
+
+    crate::pipeline::Pipeline::run(input_receiver, output_sender);
+
+    loop {
+        match output_receiver.try_recv() {
+            Ok(out_packet) => println!("Received {:?}", out_packet),
+            Err(crossbeam_channel::TryRecvError::Empty)
+            | Err(crossbeam_channel::TryRecvError::Disconnected) => return,
+        }
+    }
+}

--- a/examples/trivial-identity/src/packets.rs
+++ b/examples/trivial-identity/src/packets.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone)]
+pub struct IntegerPacket {
+    pub id: u32,
+}

--- a/examples/trivial-identity/src/pipeline.rs
+++ b/examples/trivial-identity/src/pipeline.rs
@@ -1,0 +1,28 @@
+use crate::packets::IntegerPacket;
+use futures::lazy;
+use route_rs_runtime::element::IdentityElement;
+use route_rs_runtime::link::ElementLink;
+use route_rs_runtime::pipeline::{InputChannelLink, OutputChannelLink};
+
+pub struct Pipeline {}
+
+impl route_rs_runtime::pipeline::Runner for Pipeline {
+    type Input = IntegerPacket;
+    type Output = IntegerPacket;
+
+    fn run(
+        input_channel: crossbeam::Receiver<Self::Input>,
+        output_channel: crossbeam::Sender<Self::Output>,
+    ) {
+        let elem_1 = IdentityElement::new();
+
+        let link_1 = InputChannelLink::new(input_channel);
+        let link_2 = ElementLink::new(Box::new(link_1), elem_1);
+        let link_3 = OutputChannelLink::new(Box::new(link_2), output_channel);
+
+        tokio::run(lazy(|| {
+            tokio::spawn(link_3);
+            Ok(())
+        }));
+    }
+}

--- a/route-rs-runtime/src/element/identity_elements.rs
+++ b/route-rs-runtime/src/element/identity_elements.rs
@@ -4,15 +4,14 @@ use std::marker::PhantomData;
 /* IdentityElement
   This is an element that passes what it has received
 */
+#[derive(Default)]
 pub struct IdentityElement<A: Sized> {
-    id: i32,
     phantom: PhantomData<A>,
 }
 
 impl<A> IdentityElement<A> {
-    pub fn new(id: i32) -> IdentityElement<A> {
+    pub fn new() -> IdentityElement<A> {
         IdentityElement {
-            id,
             phantom: PhantomData,
         }
     }
@@ -30,15 +29,14 @@ impl<A> Element for IdentityElement<A> {
 /* AsyncIdentityElement
   This is an async element that passes what it has received
 */
+#[derive(Default)]
 pub struct AsyncIdentityElement<A: Sized> {
-    id: i32,
     phantom: PhantomData<A>,
 }
 
 impl<A> AsyncIdentityElement<A> {
-    pub fn new(id: i32) -> AsyncIdentityElement<A> {
+    pub fn new() -> AsyncIdentityElement<A> {
         AsyncIdentityElement {
-            id,
             phantom: PhantomData,
         }
     }

--- a/route-rs-runtime/src/element/mod.rs
+++ b/route-rs-runtime/src/element/mod.rs
@@ -1,2 +1,5 @@
 mod base_element;
 pub use self::base_element::*;
+
+mod identity_elements;
+pub use self::identity_elements::*;

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -5,4 +5,5 @@ extern crate tokio;
 
 pub mod element;
 pub mod link;
+pub mod pipeline;
 mod utils;

--- a/route-rs-runtime/src/link/async_link.rs
+++ b/route-rs-runtime/src/link/async_link.rs
@@ -206,8 +206,8 @@ impl<E: AsyncElement> Stream for AsyncElementProvider<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::element::{AsyncIdentityElement, IdentityElement};
     use crate::link::sync_link::ElementLink;
-    use crate::utils::test::identity_elements::{AsyncIdentityElement, IdentityElement};
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
@@ -219,7 +219,7 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -243,7 +243,7 @@ mod tests {
         let default_channel_size = 10;
         let packet_generator = immediate_stream(0..2000);
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -269,7 +269,7 @@ mod tests {
         let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets);
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let _elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -281,7 +281,7 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -306,7 +306,7 @@ mod tests {
         let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -331,8 +331,8 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new(0);
-        let elem1 = AsyncIdentityElement::new(1);
+        let elem0 = AsyncIdentityElement::new();
+        let elem1 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);
@@ -362,10 +362,10 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = IdentityElement::new(0);
-        let elem1 = AsyncIdentityElement::new(1);
-        let elem2 = IdentityElement::new(2);
-        let elem3 = AsyncIdentityElement::new(3);
+        let elem0 = IdentityElement::new();
+        let elem1 = AsyncIdentityElement::new();
+        let elem2 = IdentityElement::new();
+        let elem3 = AsyncIdentityElement::new();
 
         let elem0_link = ElementLink::new(Box::new(packet_generator), elem0);
         let elem1_link = AsyncElementLink::new(Box::new(elem0_link), elem1, default_channel_size);
@@ -398,7 +398,7 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem0 = AsyncIdentityElement::new(0);
+        let elem0 = AsyncIdentityElement::new();
 
         let elem0_link =
             AsyncElementLink::new(Box::new(packet_generator), elem0, default_channel_size);

--- a/route-rs-runtime/src/link/classify_link.rs
+++ b/route-rs-runtime/src/link/classify_link.rs
@@ -199,27 +199,12 @@ impl<E: ClassifyElement> Stream for ClassifyElementProvider<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::element::Element;
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
     use crossbeam::crossbeam_channel;
 
     use futures::future::lazy;
-
-    #[allow(dead_code)]
-    struct IdentityElement {
-        id: i32,
-    }
-
-    impl Element for IdentityElement {
-        type Input = i32;
-        type Output = i32;
-
-        fn process(&mut self, packet: Self::Input) -> Self::Output {
-            packet
-        }
-    }
 
     #[allow(dead_code)]
     struct ClassifyEvenOddElement {

--- a/route-rs-runtime/src/link/sync_link.rs
+++ b/route-rs-runtime/src/link/sync_link.rs
@@ -54,7 +54,7 @@ impl<E: Element> Stream for ElementLink<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test::identity_elements::IdentityElement;
+    use crate::element::IdentityElement;
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
@@ -69,8 +69,8 @@ mod tests {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem1 = IdentityElement::new(0);
-        let elem2 = IdentityElement::new(1);
+        let elem1 = IdentityElement::new();
+        let elem2 = IdentityElement::new();
 
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
@@ -92,8 +92,8 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem1 = IdentityElement::new(0);
-        let elem2 = IdentityElement::new(1);
+        let elem1 = IdentityElement::new();
+        let elem2 = IdentityElement::new();
 
         let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
         let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);

--- a/route-rs-runtime/src/pipeline/input_channel_link.rs
+++ b/route-rs-runtime/src/pipeline/input_channel_link.rs
@@ -1,0 +1,25 @@
+use crossbeam::crossbeam_channel;
+use futures::{Async, Poll, Stream};
+
+pub struct InputChannelLink<Input> {
+    input_channel: crossbeam::Receiver<Input>,
+}
+
+impl<Input> InputChannelLink<Input> {
+    pub fn new(input_channel: crossbeam::Receiver<Input>) -> Self {
+        InputChannelLink { input_channel }
+    }
+}
+
+impl<Input> Stream for InputChannelLink<Input> {
+    type Item = Input;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.input_channel.try_recv() {
+            Ok(packet) => Ok(Async::Ready(Some(packet))),
+            Err(crossbeam_channel::TryRecvError::Empty) => Ok(Async::NotReady),
+            Err(crossbeam_channel::TryRecvError::Disconnected) => Err(()),
+        }
+    }
+}

--- a/route-rs-runtime/src/pipeline/mod.rs
+++ b/route-rs-runtime/src/pipeline/mod.rs
@@ -1,0 +1,8 @@
+mod runner;
+pub use self::runner::*;
+
+mod input_channel_link;
+pub use self::input_channel_link::*;
+
+mod output_channel_link;
+pub use self::output_channel_link::*;

--- a/route-rs-runtime/src/pipeline/output_channel_link.rs
+++ b/route-rs-runtime/src/pipeline/output_channel_link.rs
@@ -1,0 +1,41 @@
+use crate::link::PacketStream;
+use futures::{Async, Future, Poll};
+
+pub struct OutputChannelLink<Output> {
+    input_stream: PacketStream<Output>,
+    output_channel: crossbeam::Sender<Output>,
+}
+
+impl<Output> OutputChannelLink<Output> {
+    pub fn new(
+        input_stream: PacketStream<Output>,
+        output_channel: crossbeam::Sender<Output>,
+    ) -> Self {
+        OutputChannelLink {
+            input_stream,
+            output_channel,
+        }
+    }
+}
+
+impl<Output> Future for OutputChannelLink<Output> {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            if self.output_channel.is_full() {
+                return Ok(Async::NotReady);
+            }
+
+            match try_ready!(self.input_stream.poll()) {
+                Some(packet) => {
+                    if let Err(err) = self.output_channel.try_send(packet) {
+                        panic!("OutputChannelLink: Error sending to channel: {:?}", err);
+                    }
+                }
+                None => return Ok(Async::Ready(())),
+            }
+        }
+    }
+}

--- a/route-rs-runtime/src/pipeline/runner.rs
+++ b/route-rs-runtime/src/pipeline/runner.rs
@@ -1,0 +1,10 @@
+/// Implement a pipeline in the run method, and then call in the main function of the router
+pub trait Runner {
+    type Input: Sized;
+    type Output: Sized;
+
+    fn run(
+        input_channel: crossbeam::Receiver<Self::Input>,
+        output_channel: crossbeam::Sender<Self::Output>,
+    ) -> ();
+}

--- a/route-rs-runtime/src/utils/test/mod.rs
+++ b/route-rs-runtime/src/utils/test/mod.rs
@@ -1,3 +1,2 @@
-pub mod identity_elements;
 pub mod packet_collectors;
 pub mod packet_generators;


### PR DESCRIPTION
This PR implements the pipeline structure for running a router in a binary crate, and adds an example. It also moves the IdentityElement and AsyncIdentity element to runtime::element so they can be used beyond runtime's tests.