### PR TITLE
add pre-push style hooks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Running pre-push checks..."
+echo "Running \`cargo fmt\` on each crate..."
+cargo fmt -- --check > /dev/null
+RUSTFMT_EXIT_CODE=$?
+
+if [[ $RUSTFMT_EXIT_CODE = 0 ]]; then
+  echo "Project passes \`cargo fmt\`!"
+else
+  echo "Project isn't formatted correctly. Run \`cargo fmt\` please!"
+  exit 1
+fi
+
+echo "Running \`cargo clippy\`..."
+CLIPPY_ERR=$(cargo clippy --all-targets --all-features -- -D warnings 2>&1)
+if [[ $CLIPPY_ERR =~ "error" ]]; then
+  echo "Project is uggo. Run \`cargo clippy --all-targets --all-features -- -D warnings\` and either fix or mute the errors please!."
+  exit 1
+else
+  echo "Project is stylish!"
+fi

--- a/init_dev.sh
+++ b/init_dev.sh
@@ -1,0 +1,7 @@
+echo "Symlinking .githooks directory..."
+git config core.hooksPath .githooks
+
+echo "Installing Rust style tools..."
+rustup update
+rustup component add rustfmt
+rustup component add clippy


### PR DESCRIPTION
Client side style hooks can be initialized by running `init-dev.sh`. It
essentially runs the same style checks that Travis will run before
accepting a PR, but runs on the client so you can avoid the shame of
force-pushing style fixes before a review.