### PR TITLE
Change names: Ingressor, Egressor, [type]Link

### DIFF
--- a/examples/trivial-identity/src/pipeline.rs
+++ b/examples/trivial-identity/src/pipeline.rs
@@ -20,7 +20,7 @@ impl route_rs_runtime::pipeline::Runner for Pipeline {
         let elem_1 = IdentityElement::new();
 
         let link_1 = InputChannelLink::new(input_channel);
-        let link_2 = ElementLink::new(Box::new(link_1), elem_1);
+        let link_2 = SyncLink::new(Box::new(link_1), elem_1);
         let link_3 = OutputChannelLink::new(Box::new(link_2), output_channel);
 
         tokio::run(lazy(|| {

--- a/route-rs-runtime/src/link/sync_link.rs
+++ b/route-rs-runtime/src/link/sync_link.rs
@@ -2,21 +2,21 @@ use crate::element::Element;
 use crate::link::PacketStream;
 use futures::{Async, Poll, Stream};
 
-pub struct ElementLink<E: Element> {
+pub struct SyncLink<E: Element> {
     input_stream: PacketStream<E::Input>,
     element: E,
 }
 
-impl<E: Element> ElementLink<E> {
+impl<E: Element> SyncLink<E> {
     pub fn new(input_stream: PacketStream<E::Input>, element: E) -> Self {
-        ElementLink {
+        SyncLink {
             input_stream,
             element,
         }
     }
 }
 
-impl<E: Element> Stream for ElementLink<E> {
+impl<E: Element> Stream for SyncLink<E> {
     type Item = E::Output;
     type Error = ();
 
@@ -72,8 +72,8 @@ mod tests {
         let elem1 = IdentityElement::new();
         let elem2 = IdentityElement::new();
 
-        let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
-        let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
+        let elem1_link = SyncLink::new(Box::new(packet_generator), elem1);
+        let elem2_link = SyncLink::new(Box::new(elem1_link), elem2);
 
         let (s, r) = crossbeam::crossbeam_channel::unbounded();
         let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);
@@ -95,8 +95,8 @@ mod tests {
         let elem1 = IdentityElement::new();
         let elem2 = IdentityElement::new();
 
-        let elem1_link = ElementLink::new(Box::new(packet_generator), elem1);
-        let elem2_link = ElementLink::new(Box::new(elem1_link), elem2);
+        let elem1_link = SyncLink::new(Box::new(packet_generator), elem1);
+        let elem2_link = SyncLink::new(Box::new(elem1_link), elem2);
 
         let (s, r) = crossbeam::crossbeam_channel::unbounded();
         let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);


### PR DESCRIPTION
Ben Weis is having some trouble getting this done on his macbook due to the tests not running for some reason. Something due to not enough file descriptors to run 20+ instances of tokio at once.  So I just went ahead with his naming suggestion and implemented the concept. Added him as a reviewer.  I also removed unnecessary Element words from things. 