### PR TITLE
Rewrite ClassifyElementLink to work better in pipelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     # Example crates
     # These crates show usage of route-rs features and should _not_ be published to crates.io
     "examples/trivial-identity",
+    "examples/dns-interceptor",
 ]

--- a/examples/dns-interceptor/Cargo.toml
+++ b/examples/dns-interceptor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dns-interceptor"
+version = "0.1.0"
+authors = ["Sam Gruber <sam@scgruber.com>"]
+edition = "2018"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+route-rs-runtime = { path = "../../route-rs-runtime" }
+tokio = "*"
+futures = "*"
+crossbeam = "*"

--- a/examples/dns-interceptor/LICENSE
+++ b/examples/dns-interceptor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 route-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/dns-interceptor/src/elements.rs
+++ b/examples/dns-interceptor/src/elements.rs
@@ -1,0 +1,99 @@
+use crate::packets::*;
+use route_rs_runtime::element::{ClassifyElement, Element};
+use std::collections::HashMap;
+
+pub struct SetInterfaceByDestination {
+    lan_subnet_prefix: u32,
+    lan_subnet_mask: u32,
+}
+
+impl SetInterfaceByDestination {
+    pub fn new(lan_subnet_prefix: u32, lan_subnet_mask: u32) -> Self {
+        SetInterfaceByDestination {
+            lan_subnet_prefix,
+            lan_subnet_mask,
+        }
+    }
+}
+
+impl Element for SetInterfaceByDestination {
+    type Input = (Interface, SimplePacket);
+    type Output = (Interface, SimplePacket);
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        let dest_ip = packet.1.destination.ip;
+        if (dest_ip & self.lan_subnet_mask) == self.lan_subnet_prefix {
+            (Interface::LAN, packet.1)
+        } else {
+            (Interface::WAN, packet.1)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ClassifyDNSOutput {
+    DNS,
+    Other,
+}
+
+pub struct ClassifyDNS {}
+
+impl ClassifyDNS {
+    pub fn new() -> Self {
+        ClassifyDNS {}
+    }
+}
+
+impl Element for ClassifyDNS {
+    type Input = (Interface, SimplePacket);
+    type Output = (ClassifyDNSOutput, Self::Input);
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        match packet.1.destination.port {
+            53 => (ClassifyDNSOutput::DNS, packet),
+            _ => (ClassifyDNSOutput::Other, packet),
+        }
+    }
+}
+
+impl ClassifyElement for ClassifyDNS {
+    type Class = ClassifyDNSOutput;
+    type ActualOutput = Self::Input;
+}
+
+pub struct LocalDNSInterceptor {
+    intercept_rules: HashMap<String, String>,
+}
+
+impl LocalDNSInterceptor {
+    pub fn new() -> Self {
+        let intercept_rules: HashMap<String, String> =
+            [("gateway.route-rs.local".to_string(), "10.0.0.1".to_string())]
+                .iter()
+                .cloned()
+                .collect();
+        LocalDNSInterceptor { intercept_rules }
+    }
+}
+
+impl Element for LocalDNSInterceptor {
+    type Input = (Interface, SimplePacket);
+    type Output = (Interface, SimplePacket);
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        match (
+            &packet.0,
+            self.intercept_rules.get(&packet.1.payload.to_string()),
+        ) {
+            (Interface::WAN, Some(address)) => (
+                Interface::LAN,
+                SimplePacket {
+                    source: packet.1.destination,
+                    destination: packet.1.source,
+                    payload: address.to_string(),
+                },
+            ),
+            _ => packet,
+        }
+    }
+}

--- a/examples/dns-interceptor/src/main.rs
+++ b/examples/dns-interceptor/src/main.rs
@@ -1,0 +1,80 @@
+use crate::packets::SimplePacket;
+use crate::packets::{Interface, IpAndPort};
+use crossbeam::crossbeam_channel;
+use route_rs_runtime::pipeline::Runner;
+
+mod elements;
+mod packets;
+mod pipeline;
+
+fn main() {
+    let (input_sender, input_receiver) = crossbeam_channel::unbounded();
+    let (output_sender, output_receiver) = crossbeam_channel::unbounded();
+
+    let input_packets = vec![
+        (
+            Interface::LAN,
+            SimplePacket {
+                source: IpAndPort::new([10, 0, 0, 2], 9779),
+                destination: IpAndPort::new([1, 2, 3, 4], 80),
+                payload: String::from("HTTP GET /index.html"),
+            },
+        ),
+        (
+            Interface::LAN,
+            SimplePacket {
+                source: IpAndPort::new([10, 0, 0, 2], 9779),
+                destination: IpAndPort::new([1, 2, 3, 4], 53),
+                payload: String::from("gateway.route-rs.local"),
+            },
+        ),
+    ];
+
+    let output_packets = vec![
+        (
+            Interface::WAN,
+            SimplePacket {
+                source: IpAndPort::new([10, 0, 0, 2], 9779),
+                destination: IpAndPort::new([1, 2, 3, 4], 80),
+                payload: String::from("HTTP GET /index.html"),
+            },
+        ),
+        (
+            Interface::LAN,
+            SimplePacket {
+                source: IpAndPort::new([1, 2, 3, 4], 53),
+                destination: IpAndPort::new([10, 0, 0, 2], 9779),
+                payload: String::from("10.0.0.1"),
+            },
+        ),
+    ];
+
+    for p in input_packets {
+        match input_sender.send(p.clone()) {
+            Ok(_) => println!("Sent {:?}", p),
+            Err(err) => panic!("Input channel error {}", err),
+        }
+    }
+
+    drop(input_sender);
+
+    crate::pipeline::Pipeline::run(input_receiver, output_sender);
+
+    let mut received_packets = vec![];
+    loop {
+        match output_receiver.try_recv() {
+            Ok(out_packet) => {
+                println!("Received {:?}", out_packet);
+                received_packets.push(out_packet);
+            }
+            Err(crossbeam_channel::TryRecvError::Empty)
+            | Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                // We can't guarantee the order of the packets coming out of the router
+                // Technically this test allows us to have duplicate packets which would be dumb,
+                // but there's not much reason to expect that here so this is okay for now.
+                assert!(received_packets.iter().all(|p| output_packets.contains(p)));
+                return;
+            }
+        }
+    }
+}

--- a/examples/dns-interceptor/src/packets.rs
+++ b/examples/dns-interceptor/src/packets.rs
@@ -1,0 +1,51 @@
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Interface {
+    WAN,
+    LAN,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct IpAndPort {
+    pub ip: u32,
+    pub port: u16,
+}
+
+impl IpAndPort {
+    pub fn new(ip: [u8; 4], port: u16) -> Self {
+        IpAndPort {
+            ip: u32::from_be_bytes(ip),
+            port,
+        }
+    }
+}
+
+impl Display for IpAndPort {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let octets = self.ip.to_be_bytes();
+        write!(
+            f,
+            "{}.{}.{}.{}:{}",
+            octets[0], octets[1], octets[2], octets[3], self.port
+        )
+    }
+}
+
+impl Debug for IpAndPort {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let octets = self.ip.to_be_bytes();
+        write!(
+            f,
+            "{}.{}.{}.{}:{}",
+            octets[0], octets[1], octets[2], octets[3], self.port
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SimplePacket {
+    pub source: IpAndPort,
+    pub destination: IpAndPort,
+    pub payload: String,
+}

--- a/examples/dns-interceptor/src/pipeline.rs
+++ b/examples/dns-interceptor/src/pipeline.rs
@@ -1,0 +1,47 @@
+use crate::elements::*;
+use crate::packets::*;
+use futures::lazy;
+use route_rs_runtime::link::*;
+use route_rs_runtime::pipeline::{InputChannelLink, OutputChannelLink};
+
+pub struct Pipeline {}
+
+impl route_rs_runtime::pipeline::Runner for Pipeline {
+    type Input = (Interface, SimplePacket);
+    type Output = (Interface, SimplePacket);
+
+    fn run(
+        input_channel: crossbeam::Receiver<Self::Input>,
+        output_channel: crossbeam::Sender<Self::Output>,
+    ) {
+        let elem_1 = SetInterfaceByDestination::new(u32::from_be_bytes([10, 0, 0, 0]), 0xFF00_0000);
+        let elem_2 = ClassifyDNS::new();
+        let elem_3 = LocalDNSInterceptor::new();
+
+        let link_1 = InputChannelLink::new(input_channel);
+        let link_2 = SyncLink::new(Box::new(link_1), elem_1);
+        let mut link_3 = ClassifyLink::new(
+            Box::new(link_2),
+            elem_2,
+            Box::new(|c| if c == ClassifyDNSOutput::DNS { 0 } else { 1 }),
+            10,
+            2,
+        );
+        let link_3_egressor_1 = link_3.egressors.pop().unwrap();
+        let link_3_egressor_0 = link_3.egressors.pop().unwrap();
+        let link_4 = SyncLink::new(Box::new(link_3_egressor_0), elem_3);
+        let mut link_5 = JoinLink::new(vec![Box::new(link_4), Box::new(link_3_egressor_1)], 10);
+        let link_6 = OutputChannelLink::new(Box::new(link_5.egressor), output_channel);
+
+        let link_5_ingressor_1 = link_5.ingressors.pop().unwrap();
+        let link_5_ingressor_0 = link_5.ingressors.pop().unwrap();
+
+        tokio::run(lazy(move || {
+            tokio::spawn(link_3.ingressor);
+            tokio::spawn(link_5_ingressor_0);
+            tokio::spawn(link_5_ingressor_1);
+            tokio::spawn(link_6);
+            Ok(())
+        }));
+    }
+}

--- a/route-rs-runtime/src/element/base_element.rs
+++ b/route-rs-runtime/src/element/base_element.rs
@@ -12,8 +12,14 @@ pub trait AsyncElement {
     fn process(&mut self, packet: Self::Input) -> Self::Output;
 }
 
-pub trait ClassifyElement {
-    type Packet: Sized;
-
-    fn classify(&mut self, packet: &Self::Packet) -> usize;
+pub trait ClassifyElement:
+    Element<
+    Output = (
+        <Self as ClassifyElement>::Class,
+        <Self as ClassifyElement>::ActualOutput,
+    ),
+>
+{
+    type Class: Sized;
+    type ActualOutput: Sized;
 }


### PR DESCRIPTION
This commit rewrites ClassifyElementLink to work more similarly to the
standard ElementLink. This allows us to define the dispatch from it
inline in the pipeline, which makes code generation easier in graphgen.

This commit also restructures ClassifyElement as a subtrait of Element,
which keeps the structure more consistent for our users.

examples/dns-interceptor shows the usage of ClassifyElementLink and
JoinElementLink, so we know that they mesh with the overall pipeline
implementation. A future commit will support this example with graphgen.

Fixes #77