### PR TITLE
wip: add Snort3 DAQ integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "daq-sys/libdaq"]
+	path = daq-sys/libdaq
+	url = https://github.com/moosingin3space/libdaq.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,13 @@ members = [
     "route-rs-graphgen",
     "route-rs-runtime",
 
+    # LibDAQ crates
+    # These crates are used for network I/O and might be published to crates.io
+    "daq-sys",
+    "daquiris",
+
     # Example crates
     # These crates show usage of route-rs features and should _not_ be published to crates.io
     "examples/trivial-identity",
+    "examples/daquiris-packet-counter",
 ]

--- a/daq-sys/Cargo.toml
+++ b/daq-sys/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "daq-sys"
+version = "0.1.0"
+authors = ["Nathan Moos <moosingin3space@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[build-dependencies]
+bindgen = "0.51.0"
+cmake = "0.1.41"
+pkg-config = "0.3.15"
+
+[features]
+pcap = []
+afpacket = []

--- a/daq-sys/build.rs
+++ b/daq-sys/build.rs
@@ -1,0 +1,89 @@
+use cmake;
+
+use std::{
+    env,
+    path::PathBuf};
+
+fn build_bundled_libdaq() -> PathBuf {
+    let mut cfg = cmake::Config::new("libdaq");
+    cfg.profile("release");
+
+    let mut bundled_modules = Vec::new();
+
+    // always build trace and fst
+    bundled_modules.push("trace");
+    bundled_modules.push("fst");
+    
+    if cfg!(feature = "pcap") {
+        bundled_modules.push("pcap");
+    }
+    if cfg!(feature = "dump") {
+        bundled_modules.push("dump");
+    }
+    if cfg!(feature = "bpf") {
+        bundled_modules.push("bpf");
+    }
+    if cfg!(feature = "afpacket") {
+        bundled_modules.push("afpacket");
+    }
+    if cfg!(feature = "netmap") {
+        bundled_modules.push("netmap");
+    }
+    if cfg!(feature = "nfq") {
+        bundled_modules.push("nfq");
+    }
+    if cfg!(feature = "divert") {
+        bundled_modules.push("divert");
+    }
+
+    cfg.define("BUNDLED_MODULES", bundled_modules.join(";"));
+
+    cfg.build()
+}
+
+fn generate_bindings(include_paths: Vec<PathBuf>) {
+    let mut builder = bindgen::Builder::default()
+        .header("src/wrapper.h");
+    for p in &include_paths {
+        builder = builder.clang_arg(format!("-I{}", p.display()));
+    }
+    let bindings = builder.generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("failed to write bindings");
+}
+
+fn main() {
+    // TODO add support for pkg_config search
+    let libdaq_path = build_bundled_libdaq();
+    println!("cargo:rustc-link-search={}", libdaq_path.join("lib").display());
+    println!("cargo:rustc-link-search={}", libdaq_path.join("lib64").display());
+    println!("cargo:rustc-link-lib=static=daq");
+    println!("cargo:rustc-link-lib=static=daq_static_trace");
+    println!("cargo:rustc-link-lib=static=daq_static_fst");
+    if cfg!(feature = "pcap") {
+        println!("cargo:rustc-link-lib=static=daq_static_pcap");
+    }
+    if cfg!(feature = "afpacket") {
+        println!("cargo:rustc-link-lib=static=daq_static_afpacket");
+    }
+    if cfg!(feature = "netmap") {
+        println!("cargo:rustc-link-lib=static=daq_static_netmap");
+    }
+    if cfg!(feature = "dump") {
+        println!("cargo:rustc-link-lib=static=daq_static_dump");
+    }
+    if cfg!(feature = "nfq") {
+        println!("cargo:rustc-link-lib=static=daq_static_nfq");
+    }
+    if cfg!(feature = "divert") {
+        println!("cargo:rustc-link-lib=static=daq_static_divert");
+    }
+    if cfg!(feature = "bpf") {
+        println!("cargo:rustc-link-lib=static=daq_static_bpf");
+    }
+    generate_bindings(vec![libdaq_path.join("include")]);
+}

--- a/daq-sys/src/lib.rs
+++ b/daq-sys/src/lib.rs
@@ -1,0 +1,5 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/daq-sys/src/wrapper.h
+++ b/daq-sys/src/wrapper.h
@@ -1,0 +1,3 @@
+#include <daq.h>
+#include <daq_dlt.h>
+#include <daq_module_api.h>

--- a/daquiris/Cargo.toml
+++ b/daquiris/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "daquiris"
+version = "0.1.0"
+authors = ["Nathan Moos <moosingin3space@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+daq-sys = { path = "../daq-sys" }
+libc = "0.2.62"
+failure = "0.1.5"
+
+[features]
+pcap = ["daq-sys/pcap"]
+afpacket = ["daq-sys/afpacket"]

--- a/daquiris/src/context.rs
+++ b/daquiris/src/context.rs
@@ -1,0 +1,36 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use libc::c_int;
+use daq_sys;
+use crate::{static_modules, errors::{Error, ErrorKind}};
+
+struct Internal;
+pub struct Context {
+    _phantom: Internal,
+}
+
+static CONTEXT_CREATED : AtomicBool = AtomicBool::new(false);
+
+impl Context {
+    pub fn new() -> Result<Context, Error> {
+        if CONTEXT_CREATED.compare_and_swap(false, true, Ordering::Relaxed) {
+            Err(ErrorKind::SingletonViolation)?
+        } else {
+            static_modules::init();
+            Ok(Context { _phantom: Internal })
+        }
+    }
+
+    pub fn verbosity() -> i32 {
+        unsafe { daq_sys::daq_get_verbosity() as i32 }
+    }
+
+    pub fn set_verbosity(level: i32) {
+        unsafe { daq_sys::daq_set_verbosity(level as c_int) }
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe { daq_sys::daq_unload_modules(); }
+    }
+}

--- a/daquiris/src/lib.rs
+++ b/daquiris/src/lib.rs
@@ -1,0 +1,12 @@
+mod errors;
+mod context;
+mod static_modules;
+mod config;
+mod version;
+mod module;
+
+pub use errors::{Error, ErrorKind};
+pub use version::{version, version_str};
+pub use module::{Module};
+pub use context::{Context};
+pub use config::{Config};

--- a/daquiris/src/module.rs
+++ b/daquiris/src/module.rs
@@ -1,0 +1,42 @@
+use std::{
+    borrow::{Cow},
+    ffi::{CStr}};
+use daq_sys::{
+    DAQ_Module_h,
+    daq_find_module,
+    daq_module_get_name, daq_module_get_version,
+    daq_module_get_type};
+use crate::Context;
+
+pub struct Module<'a> {
+    _ctx: &'a Context,
+    pub(crate) module: DAQ_Module_h,
+}
+
+impl Module<'_> {
+    pub fn find<'a>(_ctx: &'a Context, name: &CStr) -> Option<Module<'a>> {
+        unsafe {
+            let m = daq_find_module(name.as_ptr());
+            if m.is_null() {
+                None
+            } else {
+                Some(Module { _ctx, module: m })
+            }
+        }
+    }
+
+    pub fn name(&self) -> Cow<str> {
+        let nm = unsafe { CStr::from_ptr(daq_module_get_name(self.module)) };
+        nm.to_string_lossy()
+    }
+
+    pub fn version(&self) -> u32 {
+        unsafe { daq_module_get_version(self.module) }
+    }
+
+    pub fn modtype(&self) -> u32 {
+        unsafe { daq_module_get_type(self.module) }
+    }
+
+    // TODO add variable descriptions
+}

--- a/daquiris/src/static_modules.rs
+++ b/daquiris/src/static_modules.rs
@@ -1,0 +1,36 @@
+use std::ptr;
+use daq_sys::{DAQ_Module_h, DAQ_ModuleAPI_t};
+
+extern "C" {
+    #[cfg(feature = "pcap")]
+    static pcap_daq_module_data: DAQ_ModuleAPI_t;
+
+    #[cfg(feature = "afpacket")]
+    static afpacket_daq_module_data: DAQ_ModuleAPI_t;
+}
+
+#[cfg(feature = "pcap")]
+unsafe fn add_pcap(mods: &mut Vec<DAQ_Module_h>) {
+    mods.push(&pcap_daq_module_data as DAQ_Module_h);
+}
+
+#[cfg(not(feature = "pcap"))]
+unsafe fn add_pcap(_mods: &mut Vec<DAQ_Module_h>) { }
+
+#[cfg(feature = "afpacket")]
+unsafe fn add_afpkt(mods: &mut Vec<DAQ_Module_h>) {
+    mods.push(&afpacket_daq_module_data as DAQ_Module_h);
+}
+
+#[cfg(not(feature = "afpacket"))]
+unsafe fn add_afpkt(_mods: &mut Vec<DAQ_Module_h>) { }
+
+pub(crate) fn init() {
+    let mut mods = Vec::new();
+    unsafe {
+        add_pcap(&mut mods);
+        add_afpkt(&mut mods);
+    }
+    mods.push(ptr::null());
+    unsafe { daq_sys::daq_load_static_modules(mods.as_mut_ptr()); }
+}

--- a/daquiris/src/version.rs
+++ b/daquiris/src/version.rs
@@ -1,0 +1,17 @@
+use std::{
+    ffi::CStr,
+    borrow::Cow};
+use daq_sys::{daq_version_number, daq_version_string};
+
+/// Returns the version number of the DAQ library.
+pub fn version() -> u32 {
+    unsafe { daq_version_number() }
+}
+
+/// Returns the version number (as a string) of the DAQ library.
+pub fn version_str() -> Cow<'static, str> {
+    unsafe {
+        let slice = CStr::from_ptr(daq_version_string());
+        slice.to_string_lossy()
+    }
+}

--- a/examples/daquiris-packet-counter/Cargo.toml
+++ b/examples/daquiris-packet-counter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "daquiris-packet-counter"
+version = "0.1.0"
+authors = ["Nathan Moos <moosingin3space@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+daquiris = { path = "../../daquiris", features = [ "afpacket" ] }

--- a/examples/daquiris-packet-counter/src/main.rs
+++ b/examples/daquiris-packet-counter/src/main.rs
@@ -1,0 +1,39 @@
+use std::{process};
+use daquiris;
+
+macro_rules! cstr_ptr {
+    ($s:expr) => {
+        concat!($s, "\0") as *const str as *const [::std::os::raw::c_char] as *const ::std::os::raw::c_char
+    };
+}
+
+macro_rules! cstr {
+    ($s:expr) => (
+        unsafe { ::std::ffi::CStr::from_ptr(cstr_ptr!($s)) }
+    );
+    ($s:expr, $($arg:expr),*) => (
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(&format!(concat!($s, "\0"), $($arg),*).into_bytes()) }
+    );
+}
+
+fn main() -> Result<(), daquiris::Error> {
+    println!("DAQuiris version: {}", daquiris::version_str());
+
+    let ctx = daquiris::Context::new()?;
+
+    match daquiris::Module::find(&ctx, cstr!("afpacket")) {
+        Some(_) => println!("DAQuiris loaded afpacket module"),
+        None => {
+            println!("DAQuiris could not find afpacket module");
+            process::exit(1)
+        }
+    }
+
+    let mut cfg = daquiris::Config::new()?;
+    cfg.set_input(cstr!("eth0:eth1"))?;
+    println!("configured message pool size: {}", cfg.msg_pool_size());
+    // TODO attach modules
+
+    // TODO process incoming packets
+    Ok(())
+}


### PR DESCRIPTION
The Snort3 DAQ provides a convenient open-source API for packet
processing from an ingress port to an egress port. Our DAQ integration
introduces the following crates:

- `daq-sys` :: a crate that provides bindgen-generated bindings to
  libdaq
- `daquiris` :: a higher-level Rust crate built on top of `daq-sys`.

An example, demonstrating how to use DAQuiris, is provided.