### PR TITLE
Add checks for dependency license compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ jobs:
     - stage: lint
       install: rustup component add clippy
       script: cargo clippy --all-targets -- -D warnings
+    - stage: lint
+      install: cargo install -f cargo-deny
+      script: cargo deny check
     - stage: build
       script: cargo build --verbose
     - stage: test

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+[licenses]
+unlicensed = "deny"
+
+# This lists all of the licenses we will allow in our dependencies. Since route-rs is distributed
+# under the MIT license, we want to make sure all of our dependencies are similarly unrestrictive.
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-2-Clause-FreeBSD",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "ISC",
+    "MIT",
+    "Unlicense",
+]
+
+[[licenses.ignore]]
+name = "crossbeam-channel"
+license_files = [
+    # This is a concatenation of several different licenses for third party code included in
+    # crossbeam-channel. Each of them is included in the list above.
+   { path = "LICENSE-THIRD-PARTY", hash = 0xc6242648 }
+]

--- a/examples/trivial-identity/Cargo.toml
+++ b/examples/trivial-identity/Cargo.toml
@@ -3,6 +3,7 @@ name = "trivial-identity"
 version = "0.1.0"
 authors = ["Sam Gruber <sam@scgruber.com>"]
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/trivial-identity/LICENSE
+++ b/examples/trivial-identity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 route-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/route-rs-graphgen/Cargo.toml
+++ b/route-rs-graphgen/Cargo.toml
@@ -3,6 +3,7 @@ name = "route-rs-graphgen"
 version = "0.1.0"
 authors = ["Sam Gruber <sam@scgruber.com>"]
 edition = "2018"
+license = "MIT"
 
 [dependencies]
 clap = "*"

--- a/route-rs-graphgen/LICENSE
+++ b/route-rs-graphgen/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 route-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/route-rs-runtime/Cargo.toml
+++ b/route-rs-runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "route-rs-runtime"
 version = "0.1.0"
 authors = ["Collin Valley <collin.valley@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 [dependencies]
 tokio = "*"

--- a/route-rs-runtime/LICENSE
+++ b/route-rs-runtime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 route-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Since route-rs is distributed under the MIT license, we want to make
sure that all of our dependencies are similarly nonrestrictive.
Our users will have to treat our package like the most restrictive
license in our dependency tree when deciding if it is usable in their
projects, so we should make this an easy decision for them.

This commit uses cargo-deny to enforce licensing, and updates our own
crates to properly record license information. We also have to
whitelist LICENSE-THIRD-PARTY in crossbeam-channel because it confuses
the scanner. I have manually inspected that license and it is just a
concatenation of licenses that are in our whitelist.