### PR TITLE
TransformElements: new elem w/ different I/O types

### DIFF
--- a/route-rs-runtime/src/element/mod.rs
+++ b/route-rs-runtime/src/element/mod.rs
@@ -3,3 +3,6 @@ pub use self::base_element::*;
 
 mod identity_elements;
 pub use self::identity_elements::*;
+
+mod transform_elements;
+pub use self::transform_elements::*;

--- a/route-rs-runtime/src/element/transform_elements.rs
+++ b/route-rs-runtime/src/element/transform_elements.rs
@@ -1,0 +1,40 @@
+use crate::element::{AsyncElement, Element};
+use std::convert::From;
+use std::marker::PhantomData;
+
+/*
+  TransformElement
+  This is an element that takes type A and passes the equivalent type B using From
+*/
+#[derive(Default)]
+pub struct TransformElement<A: Sized, B: Sized> {
+    phantom_in: PhantomData<A>,
+    phantom_out: PhantomData<B>,
+}
+
+impl<A, B> TransformElement<A, B> {
+    pub fn new() -> TransformElement<A, B> {
+        TransformElement {
+            phantom_in: PhantomData,
+            phantom_out: PhantomData,
+        }
+    }
+}
+
+impl<A, B: From<A>> Element for TransformElement<A, B> {
+    type Input = A;
+    type Output = B;
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        Self::Output::from(packet)
+    }
+}
+
+impl<A, B: From<A>> AsyncElement for TransformElement<A, B> {
+    type Input = A;
+    type Output = B;
+
+    fn process(&mut self, packet: Self::Input) -> Self::Output {
+        Self::Output::from(packet)
+    }
+}


### PR DESCRIPTION
Add a new trivial element for testing that has a different input and
output type. Use std::convert::From to do so generically.

Closes #63