### PR TITLE
Replace simple 'panic' on unwrap with 'expect'

### DIFF
--- a/route-rs-runtime/src/link/classify_link.rs
+++ b/route-rs-runtime/src/link/classify_link.rs
@@ -83,11 +83,10 @@ impl<E: ClassifyElement> Drop for ClassifyIngressor<E> {
     fn drop(&mut self) {
         //TODO: do this with a closure or something, this could be a one-liner
         for to_egressor in self.to_egressors.iter() {
-            if let Err(err) = to_egressor.try_send(None) {
-                panic!("ingressor: Drop: try_send to provider, fail?: {:?}", err);
-            }
+            to_egressor
+                .try_send(None)
+                .expect("ClassifyIngressor::Drop: try_send to_egressor shouldn't fail");
         }
-
         for task_park in self.task_parks.iter() {
             die_and_notify(&task_park);
         }

--- a/route-rs-runtime/src/pipeline/output_channel_link.rs
+++ b/route-rs-runtime/src/pipeline/output_channel_link.rs
@@ -29,11 +29,10 @@ impl<Output> Future for OutputChannelLink<Output> {
             }
 
             match try_ready!(self.input_stream.poll()) {
-                Some(packet) => {
-                    if let Err(err) = self.output_channel.try_send(packet) {
-                        panic!("OutputChannelLink: Error sending to channel: {:?}", err);
-                    }
-                }
+                Some(packet) => self
+                    .output_channel
+                    .try_send(packet)
+                    .expect("OutputChannelLink::Poll: try_send to_egressor shouldn't fail"),
                 None => return Ok(Async::Ready(())),
             }
         }

--- a/route-rs-runtime/src/utils/test/packet_collectors.rs
+++ b/route-rs-runtime/src/utils/test/packet_collectors.rs
@@ -55,12 +55,9 @@ impl<T: Debug> Future for ExhaustiveCollector<T> {
         loop {
             match try_ready!(self.stream.poll()) {
                 Some(value) => {
-                    if let Err(err) = self.packet_dump.try_send(value) {
-                        panic!(
-                            "Exhaustive Collector: Error sending to packet dump: {:?}",
-                            err
-                        );
-                    };
+                    self.packet_dump
+                        .try_send(value)
+                        .expect("Exhaustive Collector: Error sending to packet dump");
                 }
                 None => return Ok(Async::Ready(())),
             }


### PR DESCRIPTION
There are many places where a Option is checked/unwrapped and then
panics if None. This can be replaced with expect.

There are some more complicated panics that print other variables.
This would require a closure to generate the string if using an
expect. Will consider later.