### PR TITLE
Classify traits

### DIFF
--- a/examples/dns-interceptor/src/elements.rs
+++ b/examples/dns-interceptor/src/elements.rs
@@ -1,5 +1,5 @@
 use crate::packets::*;
-use route_rs_runtime::element::{ClassifyElement, Element};
+use route_rs_runtime::element::{Classifier, Element};
 use std::collections::HashMap;
 
 pub struct SetInterfaceByDestination {
@@ -44,21 +44,16 @@ impl ClassifyDNS {
     }
 }
 
-impl Element for ClassifyDNS {
-    type Input = (Interface, SimplePacket);
-    type Output = (ClassifyDNSOutput, Self::Input);
+impl Classifier for ClassifyDNS {
+    type Packet = (Interface, SimplePacket);
+    type Class = ClassifyDNSOutput;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output {
+    fn classify(&self, packet: &Self::Packet) -> Self::Class {
         match packet.1.destination.port {
-            53 => (ClassifyDNSOutput::DNS, packet),
-            _ => (ClassifyDNSOutput::Other, packet),
+            53 => ClassifyDNSOutput::DNS,
+            _ => ClassifyDNSOutput::Other,
         }
     }
-}
-
-impl ClassifyElement for ClassifyDNS {
-    type Class = ClassifyDNSOutput;
-    type ActualOutput = Self::Input;
 }
 
 pub struct LocalDNSInterceptor {

--- a/route-rs-runtime/src/element/base_element.rs
+++ b/route-rs-runtime/src/element/base_element.rs
@@ -11,15 +11,3 @@ pub trait AsyncElement {
 
     fn process(&mut self, packet: Self::Input) -> Self::Output;
 }
-
-pub trait ClassifyElement:
-    Element<
-    Output = (
-        <Self as ClassifyElement>::Class,
-        <Self as ClassifyElement>::ActualOutput,
-    ),
->
-{
-    type Class: Sized;
-    type ActualOutput: Sized;
-}

--- a/route-rs-runtime/src/element/classifier.rs
+++ b/route-rs-runtime/src/element/classifier.rs
@@ -1,0 +1,8 @@
+/// Used by a ClassifyLink to determine the kind of packet we have. Classifier::Class is then
+/// consumed by the dispatcher on the ClassifyLink to send it down the appropriate path.
+pub trait Classifier {
+    type Packet: Sized;
+    type Class: Sized;
+
+    fn classify(&self, packet: &Self::Packet) -> Self::Class;
+}

--- a/route-rs-runtime/src/element/mod.rs
+++ b/route-rs-runtime/src/element/mod.rs
@@ -9,3 +9,6 @@ pub use self::transform_elements::*;
 
 mod dec_ip_hop;
 pub use self::dec_ip_hop::*;
+
+mod classifier;
+pub use self::classifier::*;

--- a/route-rs-runtime/src/link/async_link.rs
+++ b/route-rs-runtime/src/link/async_link.rs
@@ -142,7 +142,7 @@ pub struct AsyncEgressor<Packet: Sized> {
 }
 
 impl<Packet: Sized> AsyncEgressor<Packet> {
-    fn new(
+    pub fn new(
         from_ingressor: Receiver<Option<Packet>>,
         task_park: Arc<AtomicCell<TaskParkState>>,
     ) -> Self {


### PR DESCRIPTION
This PR does two things:

- Restructure the trait for the element inside ClassifyLink to no longer subtrait from Element. This means we can clearly take an immutable reference to the packet and derive a class for dispatching.
- Tighten the Egressor trait bounds enough that yes we can throw away ClassifyEgressor and just use AsyncEgressor inside ClassifyLink. Yay deleting code.