### PR TITLE
Docs improved, tests cleaned up, names improved.

### DIFF
--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -3,7 +3,26 @@ extern crate futures;
 extern crate crossbeam;
 extern crate tokio;
 
+/// Elements are the unit of transformation in route-rs. The Element is defined by a trait that requires that
+/// creators of elements implement a process function, that the underlying link will call on every packet that
+/// moves through it. You can use elements to classify, modify headers, count packets, update state, create new packets,
+/// join packets, whatever you want! As long as an element conforms to the trait specification, the element can be run inside a route-rs.
+/// While there are many provided elements that can be used to implement a router, users of route-rs that need specifc functionality
+/// in their router most likely will implement their own custom elements, conforming to the laid out element standard.
 pub mod element;
+
+/// Links are an abstraction used by the runtime to link elements together, and manage the flow of packets through the router. Elements, which
+/// implement all the non-flow business logic of the router, are loaded into links to create specfic behavior. Links are joined together via their
+/// interfaces, and the links are then dumped into a runtime to being pulling packets through the router. In general, users of route-rs are not
+/// expected to have to implement their own links, because all of the desired flows should already be representable with the provided selection.
+/// Links are usually declared, connected, and placed into a runtime via generated code, where the user lays out their desired graph of elements
+/// and our graphgen program creates the pipeline that defines the desired router. If you are looking for a place to start, start there.
 pub mod link;
+
+/// Pipelines are abstractions used by graphgen to define a grouping of links that are run by the runtime, in our case Tokio. The graphgen
+/// program takes the user provided graph, and generates a pipeline. It connects input and output channels to the pipe, so that it can be
+/// hooked up to packet sources and sinks, and drops the pipeline into the runtime. Generally can be abstracted to the concept, router.
 pub mod pipeline;
+
+/// Utility module
 mod utils;

--- a/route-rs-runtime/src/link/async_link.rs
+++ b/route-rs-runtime/src/link/async_link.rs
@@ -214,114 +214,114 @@ mod tests {
     use futures::future::lazy;
 
     #[test]
-    fn one_async_element() {
+    fn async_link() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn one_async_element_long_stream() {
+    fn long_stream() {
         let default_channel_size = 10;
         let packet_generator = immediate_stream(0..2000);
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output.len(), 2000);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output.len(), 2000);
     }
 
     #[test]
     #[should_panic(expected = "queue capacity must be non-zero")]
-    fn one_async_element_empty_channel() {
+    fn empty_channel() {
         let default_channel_size = 0;
         let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets);
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let _elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let _link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
     }
 
     #[test]
-    fn one_async_element_small_channel() {
+    fn small_channel() {
         let default_channel_size = 1;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn one_async_element_empty_stream() {
+    fn empty_stream() {
         let default_channel_size = 10;
         let packets: Vec<i32> = vec![];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn two_async_elements() {
+    fn two_links() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
@@ -329,28 +329,28 @@ mod tests {
         let elem0 = AsyncIdentityElement::new();
         let elem1 = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
-        let elem1_link = AsyncLink::new(Box::new(elem0_link.egressor), elem1, default_channel_size);
+        let link0 = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link1 = AsyncLink::new(Box::new(link0.egressor), elem1, default_channel_size);
 
-        let elem0_drain = elem0_link.ingressor;
-        let elem1_drain = elem1_link.ingressor;
+        let drain0 = link0.ingressor;
+        let drain1 = link1.ingressor;
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem1_collector = ExhaustiveCollector::new(0, Box::new(elem1_link.egressor), s);
+        let collector = ExhaustiveCollector::new(0, Box::new(link1.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem1_collector);
+            tokio::spawn(drain0);
+            tokio::spawn(drain1);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn series_sync_and_async() {
+    fn series_of_sync_and_async_links() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
@@ -360,30 +360,30 @@ mod tests {
         let elem2 = IdentityElement::new();
         let elem3 = AsyncIdentityElement::new();
 
-        let elem0_link = SyncLink::new(Box::new(packet_generator), elem0);
-        let elem1_link = AsyncLink::new(Box::new(elem0_link), elem1, default_channel_size);
-        let elem2_link = SyncLink::new(Box::new(elem1_link.egressor), elem2);
-        let elem3_link = AsyncLink::new(Box::new(elem2_link), elem3, default_channel_size);
+        let link0 = SyncLink::new(Box::new(packet_generator), elem0);
+        let link1 = AsyncLink::new(Box::new(link0), elem1, default_channel_size);
+        let link2 = SyncLink::new(Box::new(link1.egressor), elem2);
+        let link3 = AsyncLink::new(Box::new(link2), elem3, default_channel_size);
 
-        let elem1_drain = elem1_link.ingressor;
-        let elem3_drain = elem3_link.ingressor;
+        let drain1 = link1.ingressor;
+        let drain3 = link3.ingressor;
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem3_collector = ExhaustiveCollector::new(0, Box::new(elem3_link.egressor), s);
+        let collector = ExhaustiveCollector::new(0, Box::new(link3.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem1_drain);
-            tokio::spawn(elem3_drain);
-            tokio::spawn(elem3_collector);
+            tokio::spawn(drain1);
+            tokio::spawn(drain3);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn one_async_element_wait_between_packets() {
+    fn wait_between_packets() {
         let default_channel_size = 10;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
@@ -391,46 +391,46 @@ mod tests {
             packets.clone().into_iter(),
         );
 
-        let elem0 = AsyncIdentityElement::new();
+        let elem = AsyncIdentityElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<_> = r.iter().collect();
-        assert_eq!(router_output, packets);
+        let output: Vec<_> = r.iter().collect();
+        assert_eq!(output, packets);
     }
 
     #[test]
-    fn one_async_transform_element() {
+    fn transform_element() {
         let default_channel_size = 10;
         let packets = "route-rs".chars();
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem0 = TransformElement::new();
+        let elem = TransformElement::new();
 
-        let elem0_link = AsyncLink::new(Box::new(packet_generator), elem0, default_channel_size);
+        let link = AsyncLink::new(Box::new(packet_generator), elem, default_channel_size);
 
         let (s, r) = crossbeam_channel::unbounded();
-        let elem0_drain = elem0_link.ingressor;
-        let elem0_collector = ExhaustiveCollector::new(0, Box::new(elem0_link.egressor), s);
+        let drain = link.ingressor;
+        let collector = ExhaustiveCollector::new(0, Box::new(link.egressor), s);
 
         tokio::run(lazy(|| {
-            tokio::spawn(elem0_drain);
-            tokio::spawn(elem0_collector);
+            tokio::spawn(drain);
+            tokio::spawn(collector);
             Ok(())
         }));
 
-        let router_output: Vec<u32> = r.iter().collect();
-        let expected_output: Vec<u32> = packets.map(|p| p.into()).collect();
-        assert_eq!(router_output, expected_output);
+        let output: Vec<u32> = r.iter().collect();
+        let expected: Vec<u32> = packets.map(|p| p.into()).collect();
+        assert_eq!(output, expected);
     }
 }

--- a/route-rs-runtime/src/link/blackhole_link.rs
+++ b/route-rs-runtime/src/link/blackhole_link.rs
@@ -56,7 +56,7 @@ mod tests {
     }
 
     #[test]
-    fn blackhole_link_finishes() {
+    fn finishes() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[test]
-    fn blackhole_link_with_wait_finishes() {
+    fn finishes_with_wait() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
             time::Duration::from_millis(10),
@@ -83,7 +83,7 @@ mod tests {
     }
 
     #[test]
-    fn blackhole_odd_packets() {
+    fn odd_packets() {
         let default_channel_size = 10;
         let number_branches = 2;
         let packet_generator = immediate_stream(vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9]);

--- a/route-rs-runtime/src/link/classify_link.rs
+++ b/route-rs-runtime/src/link/classify_link.rs
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn one_even_odd() {
+    fn even_odd() {
         let default_channel_size = 10;
         let number_branches = 2;
         let packet_generator = immediate_stream(vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9]);
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn one_only_odd() {
+    fn only_odd() {
         let default_channel_size = 5;
         let number_branches = 2;
         let packet_generator = immediate_stream(vec![1, 1337, 3, 5, 7, 9]);
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn one_even_odd_long_stream() {
+    fn even_odd_long_stream() {
         let default_channel_size = 10;
         let number_branches = 2;
         let packet_generator = immediate_stream(0..2000);
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn one_fizz_buzz() {
+    fn fizz_buzz() {
         let default_channel_size = 10;
         let packet_generator = immediate_stream(0..=30);
 
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn one_even_odd_wait_between_packets() {
+    fn even_odd_wait_between_packets() {
         let default_channel_size = 10;
         let number_branches = 2;
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "queue capacity must be non-zero")]
-    fn one_classify_element_empty_channel() {
+    fn empty_channel() {
         let default_channel_size = 0;
         let number_branches = 2;
         let packet_generator = immediate_stream(vec![]);

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -1,23 +1,46 @@
 use futures::Stream;
 
+/// A simple pull based link.  It is pull based in the sense that packets are only fetched on the input
+/// when a packet is requested from the output. This link does not have the abilty store packets internally,
+/// so all packets that enter either immediatly leave or are dropped, as dictated by the element. Both sides of
+/// this link are on the same thread, hence the label synchronous.
 mod sync_link;
 pub use self::sync_link::*;
 
+/// Input packets are placed into an intermediate channel that are pulled from the output asynchronously.
+/// Asynchronous in that a packets may enter and leave this link asynchronously to each other.  This link is
+/// useful for creating queues in the router, buffering, and creating `Task` boundries that can be processed on
+/// different threads, or even different cores. Before packets are placed into the queue to be output, they are run
+/// through the element defined process function, often performing some sort of transformation.
 mod async_link;
 pub use self::async_link::*;
 
+/// Uses element defined classifications to sort input into different channels, a good example would
+/// be a flow that splits IPv4 and IPv6 packets, asynchronous.
 mod classify_link;
 pub use self::classify_link::*;
 
+/// Fairly combines all inputs into a single output, asynchronous.
 mod join_link;
 pub use self::join_link::*;
 
+/// Copies all input to each of its outputs, asynchronous.
 mod tee_link;
 pub use self::tee_link::*;
 
+/// Drops all packets that are ingressed, asynchronous.
 mod blackhole_link;
 pub use self::blackhole_link::*;
 
+/// The type that all links take as input, or provide as output. This allows links to be combinatorial
 pub type PacketStream<Input> = Box<dyn Stream<Item = Input, Error = ()> + Send>;
 
+/// Task Park is a structure for tasks to place their task handles when sleeping, and where they can
+/// check for other tasks that need to be awoken.  As an example, the ingressor and egressor side of
+/// an `async_link` both may attempt to sleep when they are unable to work because they are waiting on
+/// an action from the other side of the link. Generally, this occurs when the channel joining the `ingressor`
+/// and `egressor` encounter a full or empty channel, respectively. They can place their task handle in the `task_park`
+/// and expect that when the blocker has been cleared, the other side of the link will awaken them by calling `task.notify()`.
+/// `task_park` also contains logic to prevent one side from sleeping when the other side will be unable to awaken them,
+/// in order to prevent deadlocks.
 mod task_park;

--- a/route-rs-runtime/src/link/sync_link.rs
+++ b/route-rs-runtime/src/link/sync_link.rs
@@ -65,18 +65,16 @@ mod tests {
     /// the element responds correctly to an upstream source providing a series of valid packets,
     /// interleaved with Async::NotReady values, finalized by a Async::Ready(None)
     #[test]
-    fn one_sync_element() {
+    fn sync_link() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem1 = IdentityElement::new();
-        let elem2 = IdentityElement::new();
+        let elem0 = IdentityElement::new();
 
-        let elem1_link = SyncLink::new(Box::new(packet_generator), elem1);
-        let elem2_link = SyncLink::new(Box::new(elem1_link), elem2);
+        let link0 = SyncLink::new(Box::new(packet_generator), elem0);
 
         let (s, r) = crossbeam::crossbeam_channel::unbounded();
-        let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);
+        let consumer = ExhaustiveCollector::new(1, Box::new(link0), s);
 
         tokio::run(consumer);
 
@@ -85,21 +83,19 @@ mod tests {
     }
 
     #[test]
-    fn one_sync_element_wait_between_packets() {
+    fn wait_between_packets() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
         let packet_generator = PacketIntervalGenerator::new(
             time::Duration::from_millis(10),
             packets.clone().into_iter(),
         );
 
-        let elem1 = IdentityElement::new();
-        let elem2 = IdentityElement::new();
+        let elem0 = IdentityElement::new();
 
-        let elem1_link = SyncLink::new(Box::new(packet_generator), elem1);
-        let elem2_link = SyncLink::new(Box::new(elem1_link), elem2);
+        let link0 = SyncLink::new(Box::new(packet_generator), elem0);
 
         let (s, r) = crossbeam::crossbeam_channel::unbounded();
-        let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);
+        let consumer = ExhaustiveCollector::new(1, Box::new(link0), s);
 
         tokio::run(consumer);
 
@@ -108,18 +104,16 @@ mod tests {
     }
 
     #[test]
-    fn one_sync_transform_element() {
+    fn transform_element() {
         let packets = "route-rs".chars();
         let packet_generator = immediate_stream(packets.clone());
 
-        let elem1 = TransformElement::new();
-        let elem2 = IdentityElement::new();
+        let elem0 = TransformElement::new();
 
-        let elem1_link = SyncLink::new(Box::new(packet_generator), elem1);
-        let elem2_link = SyncLink::new(Box::new(elem1_link), elem2);
+        let link0 = SyncLink::new(Box::new(packet_generator), elem0);
 
         let (s, r) = crossbeam::crossbeam_channel::unbounded();
-        let consumer = ExhaustiveCollector::new(1, Box::new(elem2_link), s);
+        let consumer = ExhaustiveCollector::new(1, Box::new(link0), s);
 
         tokio::run(consumer);
 


### PR DESCRIPTION
This is a big ol boy that I have been working on, but I think it does a lot of improve the runtime codebase. It uses more standard names, improves the docs in a lot of places, and provides some narrative to the code base which will help newer people understand what is happening. 

This is a big change, so I'd like feedback on the global points but I don't want to bikeshed too hard about names or small nits.  It would be better to get a baseline setup, and then accept smaller PRs, issues from here to keep the code pipeline flowing. 

Protip, the way to generate the docs the best is `cargo doc --no-deps --open --document-private-items`