### PR TITLE
graphgen: Append struct name to element identifier

### DIFF
--- a/examples/trivial-identity/src/pipeline.rs
+++ b/examples/trivial-identity/src/pipeline.rs
@@ -17,10 +17,10 @@ impl route_rs_runtime::pipeline::Runner for Pipeline {
         input_channel: crossbeam::Receiver<Self::Input>,
         output_channel: crossbeam::Sender<Self::Output>,
     ) {
-        let elem_1 = IdentityElement::new();
+        let elem_1_identityelement = IdentityElement::new();
 
         let link_1 = InputChannelLink::new(input_channel);
-        let link_2 = SyncLink::new(Box::new(link_1), elem_1);
+        let link_2 = SyncLink::new(Box::new(link_1), elem_1_identityelement);
         let link_3 = OutputChannelLink::new(Box::new(link_2), output_channel);
 
         tokio::run(lazy(|| {

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -66,7 +66,7 @@ fn gen_element_decls(elements: &[&&NodeData]) -> (String, HashMap<String, String
     let decls: Vec<String> = elements
         .iter()
         .map(|e| {
-            let symbol = format!("elem_{}", decl_idx);
+            let symbol = format!("elem_{}_{}", decl_idx, e.node_class.to_lowercase());
             decl_idx += 1;
             element_decls_map.insert(e.xml_node_id.to_owned(), symbol.clone());
             codegen::let_new(symbol, &e.node_class, Vec::<&str>::new())


### PR DESCRIPTION
As pipelines get bigger, it becomes really hard to remember what
"elem_1" means. Therefore, this commit appends the struct name to the
identifier so that it's easier to read later on. So that clippy doesn't
get mad about casing, the struct is lowercased in place.