### PR TITLE
Element: change 'process' to return an Option<Self::Output>

### DIFF
--- a/route-rs-runtime/src/element/base_element.rs
+++ b/route-rs-runtime/src/element/base_element.rs
@@ -2,12 +2,12 @@ pub trait Element {
     type Input: Sized;
     type Output: Sized;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output;
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output>;
 }
 
 pub trait AsyncElement {
     type Input: Sized;
     type Output: Sized;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output;
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output>;
 }

--- a/route-rs-runtime/src/element/dec_ip_hop.rs
+++ b/route-rs-runtime/src/element/dec_ip_hop.rs
@@ -15,12 +15,12 @@ impl Element for DecIpv4HopLimit {
     type Input = Ipv4Packet<Vec<u8>>;
     type Output = Ipv4Packet<Vec<u8>>;
 
-    fn process(&mut self, mut packet: Self::Input) -> Self::Output {
+    fn process(&mut self, mut packet: Self::Input) -> Option<Self::Output> {
         match packet.hop_limit() {
-            0 => packet,
+            0 => Some(packet),
             ttl => {
                 packet.set_hop_limit(ttl - 1);
-                packet
+                Some(packet)
             }
         }
     }
@@ -40,12 +40,12 @@ impl Element for DecIpv6HopLimit {
     type Input = Ipv6Packet<Vec<u8>>;
     type Output = Ipv6Packet<Vec<u8>>;
 
-    fn process(&mut self, mut packet: Self::Input) -> Self::Output {
+    fn process(&mut self, mut packet: Self::Input) -> Option<Self::Output> {
         match packet.hop_limit() {
-            0 => packet,
+            0 => Some(packet),
             ttl => {
                 packet.set_hop_limit(ttl - 1);
-                packet
+                Some(packet)
             }
         }
     }
@@ -72,7 +72,7 @@ mod tests {
 
         let mut elem = DecIpv4HopLimit::new();
 
-        let packet = elem.process(packet);
+        let packet = elem.process(packet).unwrap();
 
         assert_eq!(packet.hop_limit(), init_ttl - 1);
     }
@@ -92,7 +92,7 @@ mod tests {
 
         let mut elem = DecIpv4HopLimit::new();
 
-        let packet = elem.process(packet);
+        let packet = elem.process(packet).unwrap();
 
         assert_eq!(packet.hop_limit(), 0);
     }
@@ -113,7 +113,7 @@ mod tests {
 
         let mut elem = DecIpv6HopLimit::new();
 
-        let packet = elem.process(packet);
+        let packet = elem.process(packet).unwrap();
 
         assert_eq!(packet.hop_limit(), init_ttl - 1);
     }
@@ -133,7 +133,7 @@ mod tests {
 
         let mut elem = DecIpv6HopLimit::new();
 
-        let packet = elem.process(packet);
+        let packet = elem.process(packet).unwrap();
 
         assert_eq!(packet.hop_limit(), 0);
     }

--- a/route-rs-runtime/src/element/drop_element.rs
+++ b/route-rs-runtime/src/element/drop_element.rs
@@ -1,0 +1,36 @@
+use crate::element::{AsyncElement, Element};
+use std::marker::PhantomData;
+
+/* DropElement
+  This element drops every packet that it receives
+*/
+#[derive(Default)]
+pub struct DropElement<A: Sized> {
+    phantom: PhantomData<A>,
+}
+
+impl<A> DropElement<A> {
+    pub fn new() -> DropElement<A> {
+        DropElement {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A> Element for DropElement<A> {
+    type Input = A;
+    type Output = A;
+
+    fn process(&mut self, _packet: Self::Input) -> Option<Self::Output> {
+        None
+    }
+}
+
+impl<A> AsyncElement for DropElement<A> {
+    type Input = A;
+    type Output = A;
+
+    fn process(&mut self, _packet: Self::Input) -> Option<Self::Output> {
+        None
+    }
+}

--- a/route-rs-runtime/src/element/identity_elements.rs
+++ b/route-rs-runtime/src/element/identity_elements.rs
@@ -21,8 +21,8 @@ impl<A> Element for IdentityElement<A> {
     type Input = A;
     type Output = A;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output {
-        packet
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        Some(packet)
     }
 }
 
@@ -46,7 +46,7 @@ impl<A> AsyncElement for AsyncIdentityElement<A> {
     type Input = A;
     type Output = A;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output {
-        packet
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        Some(packet)
     }
 }

--- a/route-rs-runtime/src/element/mod.rs
+++ b/route-rs-runtime/src/element/mod.rs
@@ -7,6 +7,9 @@ pub use self::identity_elements::*;
 mod transform_elements;
 pub use self::transform_elements::*;
 
+mod drop_element;
+pub use self::drop_element::*;
+
 mod dec_ip_hop;
 pub use self::dec_ip_hop::*;
 

--- a/route-rs-runtime/src/element/transform_elements.rs
+++ b/route-rs-runtime/src/element/transform_elements.rs
@@ -25,8 +25,8 @@ impl<A, B: From<A>> Element for TransformElement<A, B> {
     type Input = A;
     type Output = B;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output {
-        Self::Output::from(packet)
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        Some(Self::Output::from(packet))
     }
 }
 
@@ -34,7 +34,7 @@ impl<A, B: From<A>> AsyncElement for TransformElement<A, B> {
     type Input = A;
     type Output = B;
 
-    fn process(&mut self, packet: Self::Input) -> Self::Output {
-        Self::Output::from(packet)
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        Some(Self::Output::from(packet))
     }
 }


### PR DESCRIPTION
This commit changes the `process` function of `Element` and `AsyncElement` to return an `Option<Self::Output>` rather than `Self::Output`, so they can support packet drops by returning `None`.

`Link`s will now continue polling their input Streams until their either the Stream is exhausted, or its `Element` returns `Some(packet)`.

A `DropElement` is implemented in a similar fashion to `IdentityElement`, where it drops every packet that it receives, rather than passes it unchanged.

resolves #102 