### PR TITLE
SyncLink impls Links, minor changes to Link API and BlackHole

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [
 
     # Example crates
     # These crates show usage of route-rs features and should _not_ be published to crates.io
-    "examples/trivial-identity",
-    "examples/dns-interceptor",
-    "examples/local-dns-nat",
+    # TODO: include again when Link API has stabilized
+#    "examples/trivial-identity",
+#    "examples/dns-interceptor",
+#    "examples/local-dns-nat",
 ]

--- a/route-rs-runtime/src/link/async_link.rs
+++ b/route-rs-runtime/src/link/async_link.rs
@@ -215,8 +215,8 @@ impl<Packet: Sized> Stream for AsyncEgressor<Packet> {
 mod tests {
     use super::*;
     use crate::element::{AsyncIdentityElement, DropElement, IdentityElement, TransformElement};
-    use crate::link::sync_link::SyncLink;
-    use crate::link::{ElementLink, Link};
+    use crate::link::sync_link::SyncLinkBuilder;
+    use crate::link::{ElementLinkBuilder, LinkBuilder};
     use crate::utils::test::packet_collectors::ExhaustiveCollector;
     use crate::utils::test::packet_generators::{immediate_stream, PacketIntervalGenerator};
     use core::time;
@@ -369,14 +369,14 @@ mod tests {
         let elem2 = IdentityElement::new();
         let elem3 = AsyncIdentityElement::new();
 
-        let (_, mut egressors0) = SyncLink::new()
+        let (_, mut egressors0) = SyncLinkBuilder::new()
             .ingressors(vec![Box::new(packet_generator)])
             .element(elem0)
             .build_link();
 
         let link1 = AsyncLink::new(egressors0.remove(0), elem1, default_channel_size);
 
-        let (_, mut egressors2) = SyncLink::new()
+        let (_, mut egressors2) = SyncLinkBuilder::new()
             .ingressors(vec![Box::new(link1.egressor)])
             .element(elem2)
             .build_link();

--- a/route-rs-runtime/src/link/async_link.rs
+++ b/route-rs-runtime/src/link/async_link.rs
@@ -370,14 +370,14 @@ mod tests {
         let elem3 = AsyncIdentityElement::new();
 
         let (_, mut egressors0) = SyncLinkBuilder::new()
-            .ingressors(vec![Box::new(packet_generator)])
+            .ingressor(packet_generator)
             .element(elem0)
             .build_link();
 
         let link1 = AsyncLink::new(egressors0.remove(0), elem1, default_channel_size);
 
         let (_, mut egressors2) = SyncLinkBuilder::new()
-            .ingressors(vec![Box::new(link1.egressor)])
+            .ingressor(Box::new(link1.egressor))
             .element(elem2)
             .build_link();
 


### PR DESCRIPTION
Commit messages are pretty descriptive, but this PR takes the next leap to have `SyncLink` impl `Link`, or rather a `SyncLinkBuilder` impl `LinkBuilder`. It's up for discussion, but I think having an explicit `*Builder` makes sense since the purpose of these objects are now to keep track of enough inputs to construct some `Link`, which is now defined as the product type of the necessary `TokioRunnables` and `PacketStream<Output>` (i.e. egressors) that need to be driven and exposed, respectively. The name `Link` in particular is confusing because of its type declaration `Link<Output>`, which isn't totally clear. I've also disabled `graphgen` tests.