### PR TITLE
Remove primitive DropLink. Create DropLink composite with random weighted distribution support.

### DIFF
--- a/route-rs-runtime/src/link/composite/drop_link.rs
+++ b/route-rs-runtime/src/link/composite/drop_link.rs
@@ -100,11 +100,11 @@ mod tests {
     fn finishes() {
         let packets = vec![0, 1, 2, 420, 1337, 3, 4, 5, 6, 7, 8, 9];
 
-        let link: Link<i32> = DropLink::new()
+        let link = DropLink::new()
             .ingressor(immediate_stream(packets.clone()))
             .build_link();
 
-        let results: Vec<Vec<i32>> = run_link(link);
+        let results = run_link(link);
         assert_eq!(results[0], vec![]);
     }
 
@@ -140,7 +140,7 @@ mod tests {
             even_runnables,
             vec![even_egressors.pop().unwrap(), drop_egressors.remove(0)],
         );
-        let results: Vec<Vec<i32>> = run_link(link);
+        let results = run_link(link);
         assert_eq!(results[0], vec![0, 2, 420, 4, 6, 8]);
     }
 
@@ -154,7 +154,7 @@ mod tests {
             .seed(0)
             .build_link();
 
-        let results: Vec<Vec<i32>> = run_link(link);
+        let results = run_link(link);
         assert_eq!(results[0], vec![1, 2, 1337, 7]);
     }
 }

--- a/route-rs-runtime/src/link/composite/mod.rs
+++ b/route-rs-runtime/src/link/composite/mod.rs
@@ -7,3 +7,7 @@ pub use self::mton_link::*;
 /// and transforms it using a user provided processor to M Output streams.
 mod m_transform_n_link;
 pub use self::m_transform_n_link::*;
+
+/// Drops packets with weighted randomness.
+mod drop_link;
+pub use self::drop_link::*;

--- a/route-rs-runtime/src/link/primitive/mod.rs
+++ b/route-rs-runtime/src/link/primitive/mod.rs
@@ -26,7 +26,3 @@ pub use self::join_link::*;
 /// Copies all input to each of its outputs, asynchronous.
 mod fork_link;
 pub use self::fork_link::*;
-
-/// Drops all packets that are ingressed, asynchronous.
-mod drop_link;
-pub use self::drop_link::*;

--- a/route-rs-runtime/src/processor/drop.rs
+++ b/route-rs-runtime/src/processor/drop.rs
@@ -1,18 +1,44 @@
 use crate::processor::Processor;
+use rand::distributions::{Bernoulli, Distribution};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use std::marker::PhantomData;
 
-/* DropProcessor
-  This processor drops every packet that it receives
-*/
-#[derive(Default)]
+/// DropProcessor
+/// Drops packets with weighted randomness.
 pub struct Drop<A: Send + Clone> {
     phantom: PhantomData<A>,
+    bernouilli: Bernoulli,
+    rng: StdRng,
 }
 
 impl<A: Send + Clone> Drop<A> {
-    pub fn new() -> Drop<A> {
+    pub fn new() -> Self {
         Drop {
             phantom: PhantomData,
+            bernouilli: Bernoulli::new(1.0).unwrap(),
+            rng: StdRng::from_entropy(),
+        }
+    }
+
+    pub fn drop_chance(self, chance: f64) -> Self {
+        assert!(chance >= 0.0, "drop_chance must be positive");
+        assert!(
+            chance <= 1.0,
+            "drop_chance must be less than or equal to 1.0"
+        );
+        Drop {
+            phantom: self.phantom,
+            bernouilli: Bernoulli::new(chance).unwrap(),
+            rng: self.rng,
+        }
+    }
+
+    pub fn seed(self, int_seed: u64) -> Self {
+        Drop {
+            phantom: self.phantom,
+            bernouilli: self.bernouilli,
+            rng: StdRng::seed_from_u64(int_seed),
         }
     }
 }
@@ -21,7 +47,11 @@ impl<A: Send + Clone> Processor for Drop<A> {
     type Input = A;
     type Output = A;
 
-    fn process(&mut self, _packet: Self::Input) -> Option<Self::Output> {
-        None
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        if self.bernouilli.sample(&mut self.rng) {
+            None
+        } else {
+            Some(packet)
+        }
     }
 }

--- a/route-rs-runtime/src/processor/drop.rs
+++ b/route-rs-runtime/src/processor/drop.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 /// Drops packets with weighted randomness.
 pub struct Drop<A: Send + Clone> {
     phantom: PhantomData<A>,
-    bernouilli: Bernoulli,
+    bernoulli: Bernoulli,
     rng: StdRng,
 }
 
@@ -16,7 +16,7 @@ impl<A: Send + Clone> Drop<A> {
     pub fn new() -> Self {
         Drop {
             phantom: PhantomData,
-            bernouilli: Bernoulli::new(1.0).unwrap(),
+            bernoulli: Bernoulli::new(1.0).unwrap(),
             rng: StdRng::from_entropy(),
         }
     }
@@ -29,7 +29,7 @@ impl<A: Send + Clone> Drop<A> {
         );
         Drop {
             phantom: self.phantom,
-            bernouilli: Bernoulli::new(chance).unwrap(),
+            bernoulli: Bernoulli::new(chance).unwrap(),
             rng: self.rng,
         }
     }
@@ -37,7 +37,7 @@ impl<A: Send + Clone> Drop<A> {
     pub fn seed(self, int_seed: u64) -> Self {
         Drop {
             phantom: self.phantom,
-            bernouilli: self.bernouilli,
+            bernoulli: self.bernoulli,
             rng: StdRng::seed_from_u64(int_seed),
         }
     }
@@ -48,10 +48,16 @@ impl<A: Send + Clone> Processor for Drop<A> {
     type Output = A;
 
     fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
-        if self.bernouilli.sample(&mut self.rng) {
+        if self.bernoulli.sample(&mut self.rng) {
             None
         } else {
             Some(packet)
         }
+    }
+}
+
+impl<A: Send + Clone> Default for Drop<A> {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
Specifically, modifies the `Drop` processor to use a Bernoulli distribution to determine which packets get dropped, and moves the `DropLink` to the `composite` directory since it is now a composition of a `ProcessLink` with a `Drop` processor. I've restricted the number of ingress streams of this link to 1, since I don't want users to pay an extra cost of merging those ingress streams using a `JoinLink` unless they need to. 

It's worth noting that this implementation is _slightly_ less efficient in the always-drop case since we need to sample a Bernoulli distribution for every packet, but it's unclear if this will make a difference. If we _need_ a more efficient multi-ingress pure-drop `Link`, we can re-introduce the previous version of `DropLink` with its own tokio task, but since that doesn't seem necessary we should favor `Link` composition.
