### PR TITLE
afpacket: change unit test to be marked as ignored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ jobs:
                 cargo clippy --all-targets -- -D warnings &&
                 cargo deny check &&
                 cargo build --verbose &&
-                cargo test --verbose --all --exclude afpacket
+                cargo test --verbose

--- a/afpacket/tests/afpacket_tests.rs
+++ b/afpacket/tests/afpacket_tests.rs
@@ -6,6 +6,7 @@ use smoltcp::{phy::ChecksumCapabilities, wire};
 use std::{ffi::CString, sync::mpsc, thread, time::Duration};
 
 #[test]
+#[ignore]
 fn layer2_loopback() {
     // If this takes more than a second to occur, something's definitely wrong.
     let timeout = Duration::from_secs(1);


### PR DESCRIPTION
This way, a bare `cargo test` invocation will run all the tests
excluding the `afpacket` crate tests. In order to actually include the
`afpacket` tests, you'll have to run `cargo test -- --ignored`.