### PR TITLE
Remove LLVM-exception from deny.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
     - stage: test
       install: rustup component add rustfmt &&
                 rustup component add clippy &&
-                cargo install -f cargo-deny
+                cargo install -f --version 0.3.0 cargo-deny
       script: cargo fmt -- --check &&
                 cargo clippy --all-targets -- -D warnings &&
                 cargo deny check &&

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,6 @@ allow = [
     "ISC",
     "MIT",
     "Unlicense",
-    "LLVM-exception"
 ]
 
 [[licenses.ignore]]


### PR DESCRIPTION
In cargo-deny 0.3.0, it is no longer valid to include the exception as
a separate line item. Since our checker passes without this line, let's
remove it.

Additionally, let's be more explicit about the version of cargo-deny
that is installed so we don't get surprises in the future.