### PR TITLE
Convert graphgen to use syn in many places and fix example generation

### DIFF
--- a/examples/trivial-identity/src/pipeline.xml
+++ b/examples/trivial-identity/src/pipeline.xml
@@ -11,7 +11,7 @@
         <mxCell id="output-1" value="IntegerPacket" style="rhombus" parent="1" vertex="1">
           <mxGeometry x="400" width="100" height="100" as="geometry"/>
         </mxCell>
-        <mxCell id="processor-1" value="IdentityProcessor" style="" parent="1" vertex="1">
+        <mxCell id="processor-1" value="Identity" style="" parent="1" vertex="1">
           <mxGeometry x="200" width="100" height="100" as="geometry"/>
         </mxCell>
         <mxCell id="link-1" style="exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="input-1" target="processor-1" edge="1">

--- a/route-rs-graphgen/Cargo.toml
+++ b/route-rs-graphgen/Cargo.toml
@@ -9,3 +9,9 @@ license = "MIT"
 clap = "2.33.0"
 xml-rs = "0.8.0"
 petgraph = "0.4.13"
+proc-macro2 = "1.0.6"
+quote = "1.0.2"
+
+[dependencies.syn]
+version = "1.0.7"
+features = ["full"]

--- a/route-rs-graphgen/Cargo.toml
+++ b/route-rs-graphgen/Cargo.toml
@@ -14,4 +14,4 @@ quote = "1.0.2"
 
 [dependencies.syn]
 version = "1.0.7"
-features = ["full"]
+features = ["full", "parsing"]

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -363,8 +363,14 @@ fn gen_source_pipeline(nodes: Vec<&NodeData>, edges: Vec<&EdgeData>) -> String {
             "Pipeline",
             [
                 codegen::typedef(vec![
-                    ("Input", &input_node.node_class),
-                    ("Output", &output_node.node_class),
+                    (
+                        codegen::ident("Input"),
+                        syn::parse_str::<syn::Type>(&input_node.node_class).unwrap(),
+                    ),
+                    (
+                        codegen::ident("Output"),
+                        syn::parse_str::<syn::Type>(&output_node.node_class).unwrap(),
+                    ),
                 ]),
                 codegen::function(
                     "run",

--- a/route-rs-graphgen/tests/tests.rs
+++ b/route-rs-graphgen/tests/tests.rs
@@ -1,25 +1,27 @@
 #[allow(dead_code)]
 mod test_helper;
 
-// TODO: re-enable after Link API is stabilized
-//#[test]
-//fn trivial_identity() {
-//    let test_helper = test_helper::TestHelper::new(
-//        "trivial-identity",
-//        vec!["--rustfmt", "--local-modules", "packets"],
-//    );
-//
-//    test_helper.run_graphgen();
-//    test_helper.run_diff();
-//}
-//
-//#[test]
-//fn dns_interceptor() {
-//    let test_helper = test_helper::TestHelper::new(
-//        "dns-interceptor",
-//        vec!["--rustfmt", "--runtime-modules", "link"],
-//    );
-//
-//    test_helper.run_graphgen();
-//    test_helper.run_diff();
-//}
+#[test]
+fn trivial_identity() {
+    let test_helper = test_helper::TestHelper::new(
+        "trivial-identity",
+        vec![
+            "--rustfmt",
+            "--local-modules",
+            "packets",
+            "--runtime-modules",
+            "processor",
+        ],
+    );
+
+    test_helper.run_graphgen();
+    test_helper.run_diff();
+}
+
+#[test]
+fn dns_interceptor() {
+    let test_helper = test_helper::TestHelper::new("dns-interceptor", vec!["--rustfmt"]);
+
+    test_helper.run_graphgen();
+    test_helper.run_diff();
+}


### PR DESCRIPTION
This PR will fix graphgen to be able to generate the current version of the examples. Along the way, convert a lot of the code generation to use the `syn` crate, so we don't have to implement the AST or string conversions ourselves.

Eventually, graphgen should just produce one big `syn::File` object and then write it to the file, but for now we can generate some pieces independently and still stick them together.