### PR TITLE
Docs fixup

### DIFF
--- a/route-rs-runtime/src/classifier/mod.rs
+++ b/route-rs-runtime/src/classifier/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Classifiers are very similar to processors, but are used to differentiate a stream of packets. As such, they take each packet by reference,
 //! and are not able to modify it. They are only used in the ClassifyLink. Classifiers are able to return any type, but generally return an Enum
-//! that will enform the Dispatch section of the ClassifyLink which group each packet belongs to. The Dispatch then moves each packet to a port
+//! that will inform the Dispatch section of the ClassifyLink which group each packet belongs to. The Dispatch then moves each packet to a port
 //! based on its classification.
 mod even;
 pub use self::even::*;

--- a/route-rs-runtime/src/classifier/mod.rs
+++ b/route-rs-runtime/src/classifier/mod.rs
@@ -1,3 +1,9 @@
+//! # What are they for?
+//!
+//! Classifiers are very similar to processors, but are used to differentiate a stream of packets. As such, they take each packet by reference,
+//! and are not able to modify it. They are only used in the ClassifyLink. Classifiers are able to return any type, but generally return an Enum
+//! that will enform the Dispatch section of the ClassifyLink which group each packet belongs to. The Dispatch then moves each packet to a port
+//! based on its classification.
 mod even;
 pub use self::even::*;
 

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -1,30 +1,21 @@
+//! In brief: The runtime is what takes the basket of computation required by the user, links it together into the desired
+//! graph, and preps it to be handed to the desired runtime for running.
 #[macro_use]
 extern crate futures;
 extern crate crossbeam;
 extern crate tokio;
 
-/// Processors are the unit of transformation in route-rs. The Processor is defined by a trait that requires that
-/// creators of processors implement a process function, that the underlying link will call on every packet that
-/// moves through it. You can use processors to classify, modify headers, count packets, update state, create new packets,
-/// join packets, whatever you want! As long as an processor conforms to the trait specification, the processor can be run inside a route-rs.
-/// While there are many provided processors that can be used to implement a router, users of route-rs that need specifc functionality
-/// in their router most likely will implement their own custom processors, conforming to the laid out processor standard.
+/// Implement the basic transformations for packets in the router.
 pub mod processor;
 
+/// Implement classification functions, helping the router decide to send a packet down route A,B,C..and so on.
 pub mod classifier;
 
-/// Links are an abstraction used by the runtime to link processors together, and manage the flow of packets through the router. Processors, which
-/// implement all the non-flow business logic of the router, are loaded into links to create specfic behavior. Links are joined together via their
-/// interfaces, and the links are then dumped into a runtime to being pulling packets through the router. In general, users of route-rs are not
-/// expected to have to implement their own links, because all of the desired flows should already be representable with the provided selection.
-/// Links are usually declared, connected, and placed into a runtime via generated code, where the user lays out their desired graph of processors
-/// and our graphgen program creates the pipeline that defines the desired router. If you are looking for a place to start, start there.
+/// Wrappers around Processors and Classfiers, and implement all the movement of Packets through the Router.
 pub mod link;
 
-/// Pipelines are abstractions used by graphgen to define a grouping of links that are run by the runtime, in our case Tokio. The graphgen
-/// program takes the user provided graph, and generates a pipeline. It connects input and output channels to the pipe, so that it can be
-/// hooked up to packet sources and sinks, and drops the pipeline into the runtime. Generally can be abstracted to the concept, router.
+/// Structure that defines a complete router, with input and output interfaces that may be hooked into the host system.
 pub mod pipeline;
 
-/// Utility module
+/// Utilities for the Runtime. Mostly testing constructs.
 pub mod utils;

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 //! In brief: The runtime is what takes the basket of computation required by the user, links it together into the desired
-//! graph, and preps it to be handed to the desired runtime for running.
+//! graph, and preps it to be handed to the Tokio for running.
 #[macro_use]
 extern crate futures;
 extern crate crossbeam;
@@ -14,7 +14,7 @@ pub mod classifier;
 /// Wrappers around Processors and Classfiers, and implement all the movement of Packets through the Router.
 pub mod link;
 
-/// Structure that defines a complete router, with input and output interfaces that may be hooked into the host system.
+/// Structure meant to encapsulate a router as and input and output channel. Used by graphgen.
 pub mod pipeline;
 
 /// Utilities for the Runtime. Mostly testing constructs.

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -1,3 +1,16 @@
+//! # What are they for?
+//!
+//! Links are an abstraction used by the runtime to link processors and classifiers together, and manage the flow of packets through the router.
+//! Processors and Classifiers, which implement all the non-flow business logic of the router, are loaded into links to create specfic behavior.
+//! Links are joined together via their interfaces, and the links are then dumped into a runtime to begin pulling packets through the router.
+//! When the library user uses Graphgen, Links are declared, connected, and placed into a runtime via generated code. The user does this by laying
+//! out their desired graph of Processors and Classifiers in a graph file, and Graphgen does all the work from there! Additionally, since all links
+//! must implement the LinkBuilder trait, Links are transparently composable at no cost during runtime! The most basic links that implement Poll,
+//! Stream and Future are Primitives. Links that are made by wrapping a collection of Links are called Composites. Link composition is a great way
+//! to reduce the complexity of your router, and make its design more inspectable. Users of the library are encouraged to create their own Composite
+//! Links, but should refrain from defining new Primitive Links. This prevents the user from having to worry about the complexities of generically
+//! chaining asynchronous computation together around Channels, and you can instead focus on your packets.
+
 use crate::processor::Processor;
 use futures::{Future, Stream};
 
@@ -7,7 +20,7 @@ pub mod composite;
 
 /// Primitive links are links that individually implement all the flow based logic that can be combined to create more compilcated
 /// composite links. Users of the library should not have to implement their own primitive links, but should rather combine them into
-/// their own custom composite links. 
+/// their own custom composite links.
 pub mod primitive;
 
 /// Commmon utilities used by links, for instance the `task_park` utility used in primitive links to facilite sleeping and waking.

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -5,10 +5,12 @@ use futures::{Future, Stream};
 /// library are encourged to make their own to encourage code reuse.
 pub mod composite;
 
-// TODO: primitives docs
+/// Primitive links are links that individually implement all the flow based logic that can be combined to create more compilcated
+/// composite links. Users of the library should not have to implement their own primitive links, but should rather combine them into
+/// their own custom composite links. 
 pub mod primitive;
 
-// TODO: util docs
+/// Commmon utilities used by links, for instance the `task_park` utility used in primitive links to facilite sleeping and waking.
 mod utils;
 
 /// All Links communicate through streams of packets. This allows them to be composable.

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -1,15 +1,16 @@
 //! # What are they for?
 //!
-//! Links are an abstraction used by the runtime to link processors and classifiers together, and manage the flow of packets through the router.
+//! Links are an abstraction used by the runtime to link processors and classifiers together, to manage the flow of packets through the router.
 //! Processors and Classifiers, which implement all the non-flow business logic of the router, are loaded into links to create specfic behavior.
-//! Links are joined together via their interfaces, and the links are then dumped into a runtime to begin pulling packets through the router.
+//! Links are composed together via the `Link` trait. The `TokioRunnable` portions are handed to Tokio (some Links, such as `QueueLink`, are async
+//! and rely on Tokio to pull packets from the upstream.)
 //! When the library user uses Graphgen, Links are declared, connected, and placed into a runtime via generated code. The user does this by laying
 //! out their desired graph of Processors and Classifiers in a graph file, and Graphgen does all the work from there! Additionally, since all links
 //! must implement the LinkBuilder trait, Links are transparently composable at no cost during runtime! The most basic links that implement Poll,
 //! Stream and Future are Primitives. Links that are made by wrapping a collection of Links are called Composites. Link composition is a great way
 //! to reduce the complexity of your router, and make its design more inspectable. Users of the library are encouraged to create their own Composite
-//! Links, but should refrain from defining new Primitive Links. This prevents the user from having to worry about the complexities of generically
-//! chaining asynchronous computation together around Channels, and you can instead focus on your packets.
+//! Links by composing `Primitives` and other `CompositeLinks` together. This prevents the user from having to worry about the complexities of generically
+//! chaining asynchronous computation together around Channels; freeing you to focus on the business logic you would like your router to implement.
 
 use crate::processor::Processor;
 use futures::{Future, Stream};
@@ -18,13 +19,13 @@ use futures::{Future, Stream};
 /// library are encourged to make their own to encourage code reuse.
 pub mod composite;
 
-/// Primitive links are links that individually implement all the flow based logic that can be combined to create more compilcated
+/// Primitive links individually implement all the flow based logic that can be combined to create more compilcated
 /// composite links. Users of the library should not have to implement their own primitive links, but should rather combine them into
 /// their own custom composite links.
 pub mod primitive;
 
 /// Commmon utilities used by links, for instance the `task_park` utility used in primitive links to facilite sleeping and waking.
-mod utils;
+pub mod utils;
 
 /// All Links communicate through streams of packets. This allows them to be composable.
 pub type PacketStream<Input> = Box<dyn Stream<Item = Input, Error = ()> + Send>;
@@ -49,7 +50,7 @@ pub trait LinkBuilder<Input, Output> {
     fn build_link(self) -> Link<Output>;
 }
 
-/// `ProcessLink` and `QueueLink` should impl `ProcessorLink`, since they are required to have their
+/// `ProcessLink` and `QueueLink` impl `ProcessLinkBuilder`, since they are required to have their
 /// Inputs and Outputs match that of their `Processor`.
 pub trait ProcessLinkBuilder<P: Processor>: LinkBuilder<P::Input, P::Output> {
     fn processor(self, processor: P) -> Self;

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -2,10 +2,9 @@ use crate::link::{Link, LinkBuilder, PacketStream, ProcessLinkBuilder};
 use crate::processor::Processor;
 use futures::{Async, Poll, Stream};
 
-/// `ProcessLink` is a simple links used to process packets through the user-defined processor
-/// It does not have the ability to store packets internally, and is pull-based. So it only does
-/// work when it is called, and must either immediatly return recieved packets, or drop them.  This
-/// link is used for transformation logic.
+/// `ProcessLink` processes packets through a user-defined processor.
+/// It can not buffer packets, so it only does work when it is called. It must immediately drop
+/// or return a transformed packet.
 #[derive(Default)]
 pub struct ProcessLink<P: Processor> {
     in_stream: Option<PacketStream<P::Input>>,
@@ -30,8 +29,7 @@ impl<P: Processor> ProcessLink<P> {
 
 /// Although `Link` allows an arbitrary number of ingressors and egressors, `ProcessLink`
 /// may only have one ingress and egress stream since it lacks some kind of queue
-/// storage. In the future we might decide to restrict the interface for this link
-/// for clearer intent.
+/// storage.
 impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for ProcessLink<P> {
     fn ingressors(self, mut in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert_eq!(

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -2,6 +2,10 @@ use crate::link::{Link, LinkBuilder, PacketStream, ProcessLinkBuilder};
 use crate::processor::Processor;
 use futures::{Async, Poll, Stream};
 
+/// `ProcessLink` is a simple links used to process packets through the user-defined processor
+/// It does not have the ability to store packets internally, and is pull-based. So it only does
+/// work when it is called, and must either immediatly return recieved packets, or drop them.  This
+/// link is used for transformation logic.
 #[derive(Default)]
 pub struct ProcessLink<P: Processor> {
     in_stream: Option<PacketStream<P::Input>>,

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -7,6 +7,8 @@ use crossbeam::crossbeam_channel::{Receiver, Sender, TryRecvError};
 use futures::{Async, Future, Poll, Stream};
 use std::sync::Arc;
 
+/// A link that can be used to create queues or buffers. It also takes a processor so
+/// packets may be transformed prior to being enqueued.
 #[derive(Default)]
 pub struct QueueLink<P: Processor> {
     in_stream: Option<PacketStream<P::Input>>,

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -7,8 +7,8 @@ use crossbeam::crossbeam_channel::{Receiver, Sender, TryRecvError};
 use futures::{Async, Future, Poll, Stream};
 use std::sync::Arc;
 
-/// A link that can be used to create queues or buffers. It also takes a processor so
-/// packets may be transformed prior to being enqueued.
+/// A link used to create queues, buffers, or Task boundries. Packets may be
+/// transformed with a Processor prior to being enqueued.
 #[derive(Default)]
 pub struct QueueLink<P: Processor> {
     in_stream: Option<PacketStream<P::Input>>,

--- a/route-rs-runtime/src/link/utils/mod.rs
+++ b/route-rs-runtime/src/link/utils/mod.rs
@@ -1,8 +1,8 @@
-/// Task Park is a structure for tasks to place their task handles when sleeping, and where they can
+/// Task Park is a structure for tasks to place their task handles in when sleeping, and where they can
 /// check for other tasks that need to be awoken.  As an example, the ingressor and egressor side of
 /// an `queue_link` both may attempt to sleep when they are unable to work because they are waiting on
 /// an action from the other side of the link. Generally, this occurs when the channel joining the `ingressor`
-/// and `egressor` encounter a full or empty channel, respectively. They can place their task handle in the `task_park`
+/// and `egressor` encounter either a full or empty channel, respectively. They can place their task handle in the `task_park`
 /// and expect that when the blocker has been cleared, the other side of the link will awaken them by calling `task.notify()`.
 /// `task_park` also contains logic to prevent one side from sleeping when the other side will be unable to awaken them,
 /// in order to prevent deadlocks.

--- a/route-rs-runtime/src/link/utils/mod.rs
+++ b/route-rs-runtime/src/link/utils/mod.rs
@@ -1,9 +1,2 @@
-/// Task Park is a structure for tasks to place their task handles in when sleeping, and where they can
-/// check for other tasks that need to be awoken.  As an example, the ingressor and egressor side of
-/// an `queue_link` both may attempt to sleep when they are unable to work because they are waiting on
-/// an action from the other side of the link. Generally, this occurs when the channel joining the `ingressor`
-/// and `egressor` encounter either a full or empty channel, respectively. They can place their task handle in the `task_park`
-/// and expect that when the blocker has been cleared, the other side of the link will awaken them by calling `task.notify()`.
-/// `task_park` also contains logic to prevent one side from sleeping when the other side will be unable to awaken them,
-/// in order to prevent deadlocks.
+/// A cache for storing task handles.
 pub mod task_park;

--- a/route-rs-runtime/src/link/utils/task_park.rs
+++ b/route-rs-runtime/src/link/utils/task_park.rs
@@ -11,7 +11,7 @@ route-rs processors. These utilities should not be exposed via the Processors AP
 ///
 /// This enum represents the state machine of a task_park; A place where a task can 'park' its
 /// task handle, and expect the other task sharing this task_park to wake it up at a later time
-/// when there is work to do. A simple example exists in  `AsyncLink`. When the provider attempts
+/// when there is work to do. A simple example exists in  `QueueLink`. When the provider attempts
 /// to pull a packet from the channel, and finds it empty, it must await more packets
 /// before it can make forward progress. So it calls `park_and_notify`, which will awaken any
 /// task handle inside in the task_park, and place the task_park in the `Parked(task::Task)` state.

--- a/route-rs-runtime/src/link/utils/task_park.rs
+++ b/route-rs-runtime/src/link/utils/task_park.rs
@@ -1,3 +1,14 @@
+//! # What is it for?
+//!
+//! Task Park is a cache for task handles. Tasks can store their task handles there before sleeping, and can alert other tasks
+//! in the cache that need to be awoken. For example, the ingressor and egressor side of
+//! an `queue_link` both may attempt to sleep when they are unable to work because they are waiting on
+//! an action from the other side of the link. Generally, this occurs when the channel joining the `ingressor`
+//! and `egressor` encounter either a full or empty channel, respectively. They can place their task handle in the `task_park`
+//! and expect that when the blocker has been cleared, the other side of the link will awaken them by calling `task.notify()`.
+//! `task_park` also contains logic to prevent one side from sleeping when the other side will be unable to awaken them,
+//! in order to prevent deadlocks.
+
 use crossbeam::atomic::AtomicCell;
 use futures::task;
 use std::sync::Arc;

--- a/route-rs-runtime/src/pipeline/mod.rs
+++ b/route-rs-runtime/src/pipeline/mod.rs
@@ -1,8 +1,5 @@
 //! # What are they?
 //!
-//! Pipelines are abstractions used by graphgen to define a grouping of links that are run by the runtime, in our case Tokio. The graphgen
-//! program takes the user provided graph, and generates a pipeline. It connects input and output channels to the pipe, so that it can be
-//! hooked up to packet sources and sinks, and drops the pipeline into the runtime. Generally can be abstracted to the concept, router.
-
+//! Pipelines are abstractions used by graphgen to IO packets for a router through channels.
 mod runner;
 pub use self::runner::*;

--- a/route-rs-runtime/src/pipeline/mod.rs
+++ b/route-rs-runtime/src/pipeline/mod.rs
@@ -1,2 +1,8 @@
+//! # What are they?
+//!
+//! Pipelines are abstractions used by graphgen to define a grouping of links that are run by the runtime, in our case Tokio. The graphgen
+//! program takes the user provided graph, and generates a pipeline. It connects input and output channels to the pipe, so that it can be
+//! hooked up to packet sources and sinks, and drops the pipeline into the runtime. Generally can be abstracted to the concept, router.
+
 mod runner;
 pub use self::runner::*;

--- a/route-rs-runtime/src/pipeline/runner.rs
+++ b/route-rs-runtime/src/pipeline/runner.rs
@@ -1,4 +1,3 @@
-/// Implement a pipeline in the run method, and then call in the main function of the router
 pub trait Runner {
     type Input: Sized;
     type Output: Sized;

--- a/route-rs-runtime/src/processor/identity.rs
+++ b/route-rs-runtime/src/processor/identity.rs
@@ -1,9 +1,7 @@
 use crate::processor::Processor;
 use std::marker::PhantomData;
 
-/* IdentityProcessor
-  This is an processor that passes what it has received
-*/
+/// Processor that passes what it receives.
 #[derive(Default)]
 pub struct Identity<A: Send + Clone> {
     phantom: PhantomData<A>,

--- a/route-rs-runtime/src/processor/mod.rs
+++ b/route-rs-runtime/src/processor/mod.rs
@@ -1,9 +1,9 @@
 //! # What are they for?
 //!
 //! Processors are the unit of transformation in route-rs. The Processor is defined by a trait that requires that
-//! creators of processors implement a process function, that the underlying Link will call on every packet that
+//! creators of processors implement a `process` function; the underlying Link will call `process` every packet that
 //! moves through it. You can use processors to modify headers, count packets, update state, create new packets,
-//! join packets, whatever you want! As long as an processor conforms to the trait specification, the processor can be run inside a route-rs.
+//! join packets, whatever you want! As long as an processor conforms to the `Processor` trait, the processor can be run inside a route-rs router.
 //! While there are many provided processors that can be used to implement a router, users of route-rs that need specifc functionality
 //! in their router most likely will implement their own custom processors, conforming to the laid out processor standard.
 
@@ -19,7 +19,6 @@ pub use self::drop::*;
 mod dec_ip_hop;
 pub use self::dec_ip_hop::*;
 
-/// In order for a struct to become a Processor, it must implement this Trait.
 pub trait Processor {
     type Input: Send + Clone;
     type Output: Send + Clone;

--- a/route-rs-runtime/src/processor/mod.rs
+++ b/route-rs-runtime/src/processor/mod.rs
@@ -1,3 +1,12 @@
+//! # What are they for?
+//!
+//! Processors are the unit of transformation in route-rs. The Processor is defined by a trait that requires that
+//! creators of processors implement a process function, that the underlying Link will call on every packet that
+//! moves through it. You can use processors to modify headers, count packets, update state, create new packets,
+//! join packets, whatever you want! As long as an processor conforms to the trait specification, the processor can be run inside a route-rs.
+//! While there are many provided processors that can be used to implement a router, users of route-rs that need specifc functionality
+//! in their router most likely will implement their own custom processors, conforming to the laid out processor standard.
+
 mod identity;
 pub use self::identity::*;
 
@@ -10,6 +19,7 @@ pub use self::drop::*;
 mod dec_ip_hop;
 pub use self::dec_ip_hop::*;
 
+/// In order for a struct to become a Processor, it must implement this Trait.
 pub trait Processor {
     type Input: Send + Clone;
     type Output: Send + Clone;

--- a/route-rs-runtime/src/processor/transform_from.rs
+++ b/route-rs-runtime/src/processor/transform_from.rs
@@ -3,10 +3,9 @@ use std::convert::From;
 use std::marker::PhantomData;
 use std::marker::Send;
 
-/*
-  TransformProcessor
-  This is an processor that takes type A and passes the equivalent type B using From
-*/
+/// Transform Processor
+///
+/// A generic processor that tranforms A -> B by calling B::from(A)
 #[derive(Default)]
 pub struct TransformFrom<A: Send + Clone, B: Send + Clone> {
     phantom_in: PhantomData<A>,

--- a/route-rs-runtime/src/utils/test/packet_collectors.rs
+++ b/route-rs-runtime/src/utils/test/packet_collectors.rs
@@ -3,6 +3,8 @@ use crossbeam::crossbeam_channel::Sender;
 use futures::{Async, Future, Poll};
 use std::fmt::Debug;
 
+/// A structure that may be handed an input stream that it will exhaustively drain from until it
+/// recieves a None. Useful for testing purposes.
 pub struct ExhaustiveDrain<T: Debug> {
     id: usize,
     stream: PacketStream<T>,

--- a/route-rs-runtime/src/utils/test/packet_generators.rs
+++ b/route-rs-runtime/src/utils/test/packet_generators.rs
@@ -3,8 +3,8 @@ use futures::{stream, Async, Poll, Stream};
 use std::time::Duration;
 use tokio::timer::Interval;
 
-// Immediately yields a collection of packets to be poll'd.
-// Thin wrapper around iter_ok.
+/// Immediately yields a collection of packets to be poll'd.
+/// Thin wrapper around iter_ok.
 pub fn immediate_stream<I>(collection: I) -> PacketStream<I::Item>
 where
     I: IntoIterator,


### PR DESCRIPTION
Starting to create baseline documentation around our library. View this as a rough draft of the docs, but they are mildly usable now in the runtime after this PR

As a reminder you can build the local docs with
`cargo docs --no-deps --open` 