### PR TITLE
Packets builder improvement

### DIFF
--- a/examples/minimal-static-router/src/classifiers.rs
+++ b/examples/minimal-static-router/src/classifiers.rs
@@ -169,10 +169,10 @@ mod tests {
             0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
 
-        let mut packet_interface0 = Ipv4Packet::new(data_v4.clone(), Some(0), 14).unwrap();
-        let mut packet_interface1 = Ipv4Packet::new(data_v4.clone(), Some(0), 14).unwrap();
-        let mut packet_interface2 = Ipv4Packet::new(data_v4.clone(), Some(0), 14).unwrap();
-        let mut packet_default = Ipv4Packet::new(data_v4, Some(0), 14).unwrap();
+        let mut packet_interface0 = Ipv4Packet::from_buffer(data_v4.clone(), Some(0), 14).unwrap();
+        let mut packet_interface1 = Ipv4Packet::from_buffer(data_v4.clone(), Some(0), 14).unwrap();
+        let mut packet_interface2 = Ipv4Packet::from_buffer(data_v4.clone(), Some(0), 14).unwrap();
+        let mut packet_default = Ipv4Packet::from_buffer(data_v4, Some(0), 14).unwrap();
         packet_interface0.set_dest_addr(Ipv4Addr::new(0, 0, 0, 0));
         packet_interface1.set_dest_addr(Ipv4Addr::new(10, 0, 0, 14));
         packet_interface2.set_dest_addr(Ipv4Addr::new(192, 168, 10, 5));

--- a/examples/minimal-static-router/src/classifiers.rs
+++ b/examples/minimal-static-router/src/classifiers.rs
@@ -214,10 +214,10 @@ mod tests {
             0xd,
         ];
 
-        let mut packet_interface0 = Ipv6Packet::new(data_v6.clone(), Some(0), 14).unwrap();
-        let mut packet_interface1 = Ipv6Packet::new(data_v6.clone(), Some(0), 14).unwrap();
-        let mut packet_interface2 = Ipv6Packet::new(data_v6.clone(), Some(0), 14).unwrap();
-        let mut packet_default = Ipv6Packet::new(data_v6, Some(0), 14).unwrap();
+        let mut packet_interface0 = Ipv6Packet::from_buffer(data_v6.clone(), Some(0), 14).unwrap();
+        let mut packet_interface1 = Ipv6Packet::from_buffer(data_v6.clone(), Some(0), 14).unwrap();
+        let mut packet_interface2 = Ipv6Packet::from_buffer(data_v6.clone(), Some(0), 14).unwrap();
+        let mut packet_default = Ipv6Packet::from_buffer(data_v6, Some(0), 14).unwrap();
         packet_interface0.set_dest_addr(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
         packet_interface1.set_dest_addr(Ipv6Addr::new(0x2001, 0xdb8, 0xdead, 1, 2, 3, 4, 5));
         packet_interface2.set_dest_addr(Ipv6Addr::new(0x2001, 0xdb8, 0xbeef, 6, 7, 8, 9, 10));

--- a/examples/minimal-static-router/src/classifiers.rs
+++ b/examples/minimal-static-router/src/classifiers.rs
@@ -139,9 +139,9 @@ mod tests {
         let data_unknown: Vec<u8> = vec![
             0xde, 0xad, 0xbe, 0xef, 0xff, 0xff, 1, 2, 3, 4, 5, 6, 0xff, 0xff,
         ];
-        let frame1 = EthernetFrame::new(data_v4, 0).unwrap();
-        let frame2 = EthernetFrame::new(data_v6, 0).unwrap();
-        let frame3 = EthernetFrame::new(data_unknown, 0).unwrap();
+        let frame1 = EthernetFrame::from_buffer(data_v4, 0).unwrap();
+        let frame2 = EthernetFrame::from_buffer(data_v6, 0).unwrap();
+        let frame3 = EthernetFrame::from_buffer(data_unknown, 0).unwrap();
         let packets = vec![frame1.clone(), frame2.clone(), frame3.clone()];
 
         let link = ClassifyLink::new()

--- a/examples/minimal-static-router/src/main.rs
+++ b/examples/minimal-static-router/src/main.rs
@@ -19,8 +19,8 @@ fn main() {
         0xbe, 0xef, 0x20, 0x01, 0x0d, 0xb8, 0xbe, 0xef, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0xa, 0xb,
         0xc, 0xd,
     ];
-    let frame1 = EthernetFrame::new(data_v4, 0).unwrap();
-    let frame2 = EthernetFrame::new(data_v6, 0).unwrap();
+    let frame1 = EthernetFrame::from_buffer(data_v4, 0).unwrap();
+    let frame2 = EthernetFrame::from_buffer(data_v6, 0).unwrap();
     let packets = vec![frame1.clone(), frame2.clone()];
     // Create our router
     let router = Router::new()

--- a/examples/minimal-static-router/src/processors.rs
+++ b/examples/minimal-static-router/src/processors.rs
@@ -88,7 +88,7 @@ mod tests {
 
         let results = run_link(link);
 
-        let test_packet = Ipv4Packet::new(data, Some(0), 14).unwrap();
+        let test_packet = Ipv4Packet::from_buffer(data, Some(0), 14).unwrap();
         assert_eq!(results[0][0], test_packet);
         assert_eq!(results[0].len(), 1, "Error didn't drop second packet");
     }
@@ -99,7 +99,7 @@ mod tests {
             0xde, 0xad, 0xbe, 0xef, 0xff, 0xff, 1, 2, 3, 4, 5, 6, 0x08, 00, 0x45, 0, 0, 20, 0, 0,
             0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
-        let packet = Ipv4Packet::new(data.clone(), Some(0), 14).unwrap();
+        let packet = Ipv4Packet::from_buffer(data.clone(), Some(0), 14).unwrap();
         let packets = vec![packet];
 
         let link = ProcessLink::new()

--- a/examples/minimal-static-router/src/processors.rs
+++ b/examples/minimal-static-router/src/processors.rs
@@ -138,7 +138,7 @@ mod tests {
 
         let results = run_link(link);
 
-        let test_packet = Ipv6Packet::new(data, Some(0), 14).unwrap();
+        let test_packet = Ipv6Packet::from_buffer(data, Some(0), 14).unwrap();
         assert_eq!(results[0][0], test_packet);
         assert_eq!(
             results[0].len(),
@@ -155,7 +155,7 @@ mod tests {
             0xad, 0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xa, 0xb, 0xc,
             0xd,
         ];
-        let packet = Ipv6Packet::new(data.clone(), Some(0), 14).unwrap();
+        let packet = Ipv6Packet::from_buffer(data.clone(), Some(0), 14).unwrap();
         let packets = vec![packet];
 
         let link = ProcessLink::new()

--- a/examples/minimal-static-router/src/processors.rs
+++ b/examples/minimal-static-router/src/processors.rs
@@ -77,8 +77,8 @@ mod tests {
             0xde, 0xad, 0xbe, 0xef, 0xff, 0xff, 1, 2, 3, 4, 5, 6, 0x08, 00, 0x65, 0, 0, 20, 0, 0,
             0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
-        let frame = EthernetFrame::new(data.clone(), 0).unwrap();
-        let frame_invalid_ip = EthernetFrame::new(data2, 0).unwrap();
+        let frame = EthernetFrame::from_buffer(data.clone(), 0).unwrap();
+        let frame_invalid_ip = EthernetFrame::from_buffer(data2, 0).unwrap();
         let packets = vec![frame, frame_invalid_ip];
 
         let link = ProcessLink::new()
@@ -109,7 +109,7 @@ mod tests {
 
         let results = run_link(link);
 
-        let test_frame = EthernetFrame::new(data, 0).unwrap();
+        let test_frame = EthernetFrame::from_buffer(data, 0).unwrap();
         assert_eq!(results[0][0], test_frame);
     }
 
@@ -127,8 +127,8 @@ mod tests {
             0xad, 0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xa, 0xb, 0xc,
             0xd,
         ];
-        let frame = EthernetFrame::new(data.clone(), 0).unwrap();
-        let frame_invalid_ip = EthernetFrame::new(data2, 0).unwrap();
+        let frame = EthernetFrame::from_buffer(data.clone(), 0).unwrap();
+        let frame_invalid_ip = EthernetFrame::from_buffer(data2, 0).unwrap();
         let packets = vec![frame, frame_invalid_ip];
 
         let link = ProcessLink::new()
@@ -165,7 +165,7 @@ mod tests {
 
         let results = run_link(link);
 
-        let test_frame = EthernetFrame::new(data, 0).unwrap();
+        let test_frame = EthernetFrame::from_buffer(data, 0).unwrap();
         assert_eq!(results[0][0], test_frame);
     }
 }

--- a/route-rs-packets/src/ipv4.rs
+++ b/route-rs-packets/src/ipv4.rs
@@ -287,7 +287,7 @@ mod tests {
             0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let packet = Ipv4Packet::try_from(frame).unwrap();
@@ -315,7 +315,7 @@ mod tests {
             0x45, 0x00, 0x00, 0x14, 0x00, 0x00, 0x40, 0x00, 0x40, 0x11, 0xb8, 0x61, 0xc0, 0xa8,
             0x00, 0x01, 0xc0, 0xa8, 0x00, 0xc7,
         ];
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&invalid_checksum_data);
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
         assert!(!packet.validate_checksum());
@@ -337,7 +337,7 @@ mod tests {
             0x45, 0x00, 0x00, 0x14, 0x00, 0x00, 0x40, 0x00, 0x40, 0x11, 0xb8, 0x61, 0xc0, 0xa8,
             0x00, 0x01, 0xc0, 0xa8, 0x00, 0xc7,
         ];
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
         assert!(!packet.validate_checksum());

--- a/route-rs-packets/src/ipv4.rs
+++ b/route-rs-packets/src/ipv4.rs
@@ -12,7 +12,7 @@ pub struct Ipv4Packet {
 }
 
 impl Ipv4Packet {
-    pub fn new(
+    pub fn from_buffer(
         data: PacketData,
         layer2_offset: Option<usize>,
         layer3_offset: usize,
@@ -247,7 +247,7 @@ impl TryFrom<EthernetFrame> for Ipv4Packet {
     type Error = &'static str;
 
     fn try_from(frame: EthernetFrame) -> Result<Self, Self::Error> {
-        Ipv4Packet::new(frame.data, Some(frame.layer2_offset), frame.payload_offset)
+        Ipv4Packet::from_buffer(frame.data, Some(frame.layer2_offset), frame.payload_offset)
     }
 }
 
@@ -256,7 +256,7 @@ impl TryFrom<TcpSegment> for Ipv4Packet {
 
     fn try_from(segment: TcpSegment) -> Result<Self, Self::Error> {
         if let Some(layer3_offset) = segment.layer3_offset {
-            Ipv4Packet::new(segment.data, segment.layer2_offset, layer3_offset)
+            Ipv4Packet::from_buffer(segment.data, segment.layer2_offset, layer3_offset)
         } else {
             Err("TCP Segment does not contain an IP Packet")
         }
@@ -268,7 +268,7 @@ impl TryFrom<UdpSegment> for Ipv4Packet {
 
     fn try_from(segment: UdpSegment) -> Result<Self, Self::Error> {
         if let Some(layer3_offset) = segment.layer3_offset {
-            Ipv4Packet::new(segment.data, segment.layer2_offset, layer3_offset)
+            Ipv4Packet::from_buffer(segment.data, segment.layer2_offset, layer3_offset)
         } else {
             Err("UDP Segment does not contain an IP Packet")
         }
@@ -352,7 +352,7 @@ mod tests {
             64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
 
-        let mut packet = Ipv4Packet::new(data, Some(0), 14).unwrap();
+        let mut packet = Ipv4Packet::from_buffer(data, Some(0), 14).unwrap();
         assert_eq!(packet.ihl(), 5);
         packet.set_ihl(24);
         assert_eq!(packet.ihl(), 6);

--- a/route-rs-packets/src/ipv4.rs
+++ b/route-rs-packets/src/ipv4.rs
@@ -168,7 +168,7 @@ impl Ipv4Packet {
         self.data[self.layer3_offset + 1] >> 2
     }
 
-    /// Lower 6 bits define the dcsp
+    /// Lower 6 bits define the dscp
     pub fn set_dscp(&mut self, dcsp: u8) {
         self.data[self.layer3_offset + 1] &= 0x03;
         self.data[self.layer3_offset + 1] |= dcsp << 2;

--- a/route-rs-packets/src/ipv6.rs
+++ b/route-rs-packets/src/ipv6.rs
@@ -298,7 +298,7 @@ mod tests {
             0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D, 0x0E0F,
         );
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let packet = Ipv6Packet::try_from(frame).unwrap();

--- a/route-rs-packets/src/ipv6.rs
+++ b/route-rs-packets/src/ipv6.rs
@@ -13,7 +13,7 @@ pub struct Ipv6Packet {
 }
 
 impl Ipv6Packet {
-    pub fn new(
+    pub fn from_buffer(
         data: PacketData,
         layer2_offset: Option<usize>,
         layer3_offset: usize,
@@ -249,7 +249,7 @@ impl TryFrom<EthernetFrame> for Ipv6Packet {
     type Error = &'static str;
 
     fn try_from(frame: EthernetFrame) -> Result<Self, Self::Error> {
-        Ipv6Packet::new(frame.data, Some(frame.layer2_offset), frame.payload_offset)
+        Ipv6Packet::from_buffer(frame.data, Some(frame.layer2_offset), frame.payload_offset)
     }
 }
 
@@ -258,7 +258,7 @@ impl TryFrom<TcpSegment> for Ipv6Packet {
 
     fn try_from(segment: TcpSegment) -> Result<Self, Self::Error> {
         if let Some(layer3_offset) = segment.layer3_offset {
-            Ipv6Packet::new(segment.data, segment.layer2_offset, layer3_offset)
+            Ipv6Packet::from_buffer(segment.data, segment.layer2_offset, layer3_offset)
         } else {
             Err("TCP segment does not contain IP Header")
         }
@@ -270,7 +270,7 @@ impl TryFrom<UdpSegment> for Ipv6Packet {
 
     fn try_from(segment: UdpSegment) -> Result<Self, Self::Error> {
         if let Some(layer3_offset) = segment.layer3_offset {
-            Ipv6Packet::new(segment.data, segment.layer2_offset, layer3_offset)
+            Ipv6Packet::from_buffer(segment.data, segment.layer2_offset, layer3_offset)
         } else {
             Err("UDP segment does not contain IP Header")
         }
@@ -329,7 +329,7 @@ mod tests {
             0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D, 0x0E0F,
         );
 
-        let mut packet = Ipv6Packet::new(data, Some(0), 14).unwrap();
+        let mut packet = Ipv6Packet::from_buffer(data, Some(0), 14).unwrap();
 
         assert_eq!(packet.src_addr(), src_addr);
         packet.set_src_addr(new_src_addr);
@@ -352,7 +352,7 @@ mod tests {
             0xdead, 0xbeef, 0xdead, 0xbeef, 0xdead, 0xbeef, 0xdead, 0xbeef,
         );
 
-        let mut packet = Ipv6Packet::new(data, Some(0), 14).unwrap();
+        let mut packet = Ipv6Packet::from_buffer(data, Some(0), 14).unwrap();
 
         assert_eq!(packet.dest_addr(), dest_addr);
         packet.set_dest_addr(new_dest_addr);
@@ -367,7 +367,7 @@ mod tests {
             0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xa, 0xb, 0xc, 0xd,
         ];
 
-        let mut packet = Ipv6Packet::new(data, Some(0), 14).unwrap();
+        let mut packet = Ipv6Packet::from_buffer(data, Some(0), 14).unwrap();
 
         assert_eq!(packet.data[packet.payload_offset], 0xa);
 

--- a/route-rs-packets/src/tcp.rs
+++ b/route-rs-packets/src/tcp.rs
@@ -234,7 +234,7 @@ mod tests {
             2, 3, 4, 5, 6, 7, 8, 9, 10,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ipv4_data);
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
         packet.set_payload(&tcp_data);

--- a/route-rs-packets/src/tcp.rs
+++ b/route-rs-packets/src/tcp.rs
@@ -12,7 +12,7 @@ pub struct TcpSegment {
 }
 
 impl TcpSegment {
-    pub fn new(
+    pub fn from_buffer(
         data: PacketData,
         layer2_offset: Option<usize>,
         layer3_offset: Option<usize>,
@@ -196,7 +196,7 @@ impl TryFrom<Ipv4Packet> for TcpSegment {
     type Error = &'static str;
 
     fn try_from(packet: Ipv4Packet) -> Result<Self, Self::Error> {
-        TcpSegment::new(
+        TcpSegment::from_buffer(
             packet.data,
             packet.layer2_offset,
             Some(packet.layer3_offset),
@@ -209,7 +209,7 @@ impl TryFrom<Ipv6Packet> for TcpSegment {
     type Error = &'static str;
 
     fn try_from(packet: Ipv6Packet) -> Result<Self, Self::Error> {
-        TcpSegment::new(
+        TcpSegment::from_buffer(
             packet.data,
             packet.layer2_offset,
             Some(packet.layer3_offset),

--- a/route-rs-packets/src/udp.rs
+++ b/route-rs-packets/src/udp.rs
@@ -12,7 +12,7 @@ pub struct UdpSegment {
 }
 
 impl<'packet> UdpSegment {
-    pub fn new(
+    pub fn from_buffer(
         data: PacketData,
         layer2_offset: Option<usize>, // Prep to switch to optional
         layer3_offset: Option<usize>, // Prep to switch to optional
@@ -126,7 +126,7 @@ impl TryFrom<Ipv4Packet> for UdpSegment {
     type Error = &'static str;
 
     fn try_from(packet: Ipv4Packet) -> Result<Self, Self::Error> {
-        UdpSegment::new(
+        UdpSegment::from_buffer(
             packet.data,
             packet.layer2_offset,
             Some(packet.layer3_offset),
@@ -139,7 +139,7 @@ impl TryFrom<Ipv6Packet> for UdpSegment {
     type Error = &'static str;
 
     fn try_from(packet: Ipv6Packet) -> Result<Self, Self::Error> {
-        UdpSegment::new(
+        UdpSegment::from_buffer(
             packet.data,
             packet.layer2_offset,
             Some(packet.layer3_offset),

--- a/route-rs-packets/src/udp.rs
+++ b/route-rs-packets/src/udp.rs
@@ -163,7 +163,7 @@ mod tests {
             0, 99, 0, 88, 0, 19, 0xDE, 0xAD, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ipv4_data);
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
         packet.set_payload(&udp_data);

--- a/route-rs-runtime/src/processor/dec_ip_hop.rs
+++ b/route-rs-runtime/src/processor/dec_ip_hop.rs
@@ -65,7 +65,7 @@ mod tests {
             0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
@@ -86,7 +86,7 @@ mod tests {
             0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 192, 178, 128, 0, 10, 0, 0, 1,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let mut packet = Ipv4Packet::try_from(frame).unwrap();
@@ -109,7 +109,7 @@ mod tests {
             14, 15, 0xa, 0xb, 0xc, 0xd,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let mut packet = Ipv6Packet::try_from(frame).unwrap();
@@ -132,7 +132,7 @@ mod tests {
             14, 15, 0xa, 0xb, 0xc, 0xd,
         ];
 
-        let mut frame = EthernetFrame::new(mac_data, 0).unwrap();
+        let mut frame = EthernetFrame::from_buffer(mac_data, 0).unwrap();
         frame.set_payload(&ip_data);
 
         let mut packet = Ipv6Packet::try_from(frame).unwrap();


### PR DESCRIPTION
This is a series of commits that adjusts the interface for packets to be more ergonomic. Primarily, users now have the option of making packets either from a buffer, or as empty shells which they then populate.
To support this I also rounded out a lot of the methods on each class, so that relevant setters were available where it made sense. 
Finally, I added the ability to build a lower layer packet out of an upper layer one, by providing the encap function.