### PR TITLE
Improve links,  Ingressor() is now a required function

### DIFF
--- a/examples/minimal-static-router/src/main.rs
+++ b/examples/minimal-static-router/src/main.rs
@@ -55,8 +55,23 @@ impl LinkBuilder<EthernetFrame, EthernetFrame> for Router {
             in_streams.len() == 1,
             "Support only one input interface for now"
         );
+
+        if self.in_streams.is_some() {
+            panic!("Only support one input interface")
+        }
+
         Router {
             in_streams: Some(in_streams),
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<EthernetFrame>) -> Self {
+        if self.in_streams.is_some() {
+            panic!("Only support one input interface")
+        }
+
+        Router {
+            in_streams: Some(vec![in_stream]),
         }
     }
 

--- a/route-rs-runtime/src/link/composite/drop_link.rs
+++ b/route-rs-runtime/src/link/composite/drop_link.rs
@@ -21,14 +21,6 @@ impl<I> DropLink<I> {
         }
     }
 
-    pub fn ingressor(self, in_stream: PacketStream<I>) -> Self {
-        DropLink {
-            in_stream: Some(in_stream),
-            drop_chance: self.drop_chance,
-            seed: self.seed,
-        }
-    }
-
     pub fn drop_chance(self, chance: f64) -> Self {
         DropLink {
             in_stream: self.in_stream,
@@ -53,8 +45,25 @@ impl<I: Send + Clone + 'static> LinkBuilder<I, I> for DropLink<I> {
             1,
             "DropLink can only take 1 ingress stream"
         );
+
+        if self.in_stream.is_some() {
+            panic!("DropLink can only take 1 input stream")
+        }
+
         DropLink {
             in_stream: Some(ingress_streams.remove(0)),
+            drop_chance: self.drop_chance,
+            seed: self.seed,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<I>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("DropLink can only take 1 input stream")
+        }
+
+        DropLink {
+            in_stream: Some(in_stream),
             drop_chance: self.drop_chance,
             seed: self.seed,
         }

--- a/route-rs-runtime/src/link/composite/m_transform_n_link.rs
+++ b/route-rs-runtime/src/link/composite/m_transform_n_link.rs
@@ -25,14 +25,10 @@ impl<P: Processor + Send> MtransformNLink<P> {
     }
 
     /// Changes join_queue_capcity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn join_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "join_queue_capacity: {} must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("join_queue_capacity: {} must be > 0", queue_capacity)
         );
 
         MtransformNLink {
@@ -45,14 +41,10 @@ impl<P: Processor + Send> MtransformNLink<P> {
     }
 
     /// Changes tee_queue_capcity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn fork_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "fork_queue_capacity: {} must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("fork_queue_capacity: {} must be > 0", queue_capacity)
         );
 
         MtransformNLink {
@@ -65,11 +57,7 @@ impl<P: Processor + Send> MtransformNLink<P> {
     }
 
     pub fn num_egressors(self, num_egressors: usize) -> Self {
-        assert!(
-            num_egressors <= 1000,
-            format!("compsite num_egressors: {} > 1000", num_egressors)
-        );
-        assert_ne!(num_egressors, 0, "num_egressors must be non-zero");
+        assert_ne!(num_egressors, 0, "num_egressors must be > 0");
 
         MtransformNLink {
             in_streams: self.in_streams,
@@ -84,7 +72,7 @@ impl<P: Processor + Send> MtransformNLink<P> {
 impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for MtransformNLink<P> {
     fn ingressors(self, in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert!(
-            in_streams.len() > 0,
+            !in_streams.is_empty(),
             format!("Input streams: {} should be > 0", in_streams.len())
         );
 

--- a/route-rs-runtime/src/link/composite/mton_link.rs
+++ b/route-rs-runtime/src/link/composite/mton_link.rs
@@ -22,14 +22,10 @@ impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
     }
 
     /// Changes join_queue_capcity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn join_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "queue_capacity: {}, must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("join_queue_capacity: {}, must be > 0", queue_capacity)
         );
 
         MtoNLink {
@@ -41,14 +37,10 @@ impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
     }
 
     /// Changes tee_queue_capcity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn tee_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "queue_capacity: {}, must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("tee_queue_capacity: {}, must be > 0", queue_capacity)
         );
 
         MtoNLink {
@@ -61,11 +53,8 @@ impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
 
     pub fn num_egressors(self, num_egressors: usize) -> Self {
         assert!(
-            (1..=1000).contains(&num_egressors),
-            format!(
-                "num_egressors: {}, must be in range 1..=1000",
-                num_egressors
-            )
+            num_egressors > 0,
+            format!("num_egressors: {}, must be > 0", num_egressors)
         );
 
         MtoNLink {
@@ -80,7 +69,7 @@ impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
 impl<Packet: Sized + Send + Clone + 'static> LinkBuilder<Packet, Packet> for MtoNLink<Packet> {
     fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert!(
-            in_streams.len() > 0,
+            !in_streams.is_empty(),
             format!("Input streams: {} must be > 0", in_streams.len())
         );
 

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -26,7 +26,13 @@ pub type Link<Output> = (Vec<TokioRunnable>, Vec<PacketStream<Output>>);
 pub trait LinkBuilder<Input, Output> {
     /// Links need a way to receive input from upstream.
     /// Some Links such as `ProcessLink` will only need at most 1, but others can accept many.
+    /// Links that can not support the number of ingressors provided will panic. Links that already have
+    /// ingressors will panic on calling this function, since we expect this is a user configuration error.
     fn ingressors(self, in_streams: Vec<PacketStream<Input>>) -> Self;
+
+    /// Append ingressor to list of ingressors, works like push() for a Vector
+    /// If the link can not support the addition of another ingressor, it will panic.
+    fn ingressor(self, in_stream: PacketStream<Input>) -> Self;
 
     /// Provides any tokio-driven Futures needed to drive the Link, as well as handles for downstream
     /// `Link`s to use. This method consumes the `Link` since we want to move ownership of a `Link`'s

--- a/route-rs-runtime/src/link/primitive/classify_link.rs
+++ b/route-rs-runtime/src/link/primitive/classify_link.rs
@@ -83,16 +83,6 @@ impl<C: Classifier> ClassifyLink<C> {
             num_egressors: Some(num_egressors),
         }
     }
-
-    pub fn ingressor(self, in_stream: PacketStream<C::Packet>) -> Self {
-        ClassifyLink {
-            in_stream: Some(in_stream),
-            classifier: self.classifier,
-            dispatcher: self.dispatcher,
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
-    }
 }
 
 impl<C: Classifier + Send + 'static> LinkBuilder<C::Packet, C::Packet> for ClassifyLink<C> {
@@ -103,8 +93,26 @@ impl<C: Classifier + Send + 'static> LinkBuilder<C::Packet, C::Packet> for Class
             "ClassifyLink may only take 1 input stream"
         );
 
+        if self.in_stream.is_some() {
+            panic!("ClassifyLink may only take 1 input stream")
+        }
+
         ClassifyLink {
             in_stream: Some(in_streams.remove(0)),
+            classifier: self.classifier,
+            dispatcher: self.dispatcher,
+            queue_capacity: self.queue_capacity,
+            num_egressors: self.num_egressors,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<C::Packet>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("ClassifyLink may only take 1 input stream")
+        }
+
+        ClassifyLink {
+            in_stream: Some(in_stream),
             classifier: self.classifier,
             dispatcher: self.dispatcher,
             queue_capacity: self.queue_capacity,

--- a/route-rs-runtime/src/link/primitive/classify_link.rs
+++ b/route-rs-runtime/src/link/primitive/classify_link.rs
@@ -52,11 +52,8 @@ impl<C: Classifier> ClassifyLink<C> {
 
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "Queue capacity: {}, must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("Queue capacity: {}, must be > 0", queue_capacity)
         );
         ClassifyLink {
             in_stream: self.in_stream,
@@ -69,11 +66,8 @@ impl<C: Classifier> ClassifyLink<C> {
 
     pub fn num_egressors(self, num_egressors: usize) -> Self {
         assert!(
-            (1..=1000).contains(&num_egressors),
-            format!(
-                "num_egressors: {}, must be in range 1..=1000",
-                num_egressors
-            )
+            num_egressors > 0,
+            format!("num_egressors: {}, must be > 0", num_egressors)
         );
         ClassifyLink {
             in_stream: self.in_stream,
@@ -189,7 +183,6 @@ impl<'a, C: Classifier> ClassifyIngressor<'a, C> {
 
 impl<'a, C: Classifier> Drop for ClassifyIngressor<'a, C> {
     fn drop(&mut self) {
-        //TODO: do this with a closure or something, this could be a one-liner
         for to_egressor in self.to_egressors.iter() {
             to_egressor
                 .try_send(None)

--- a/route-rs-runtime/src/link/primitive/fork_link.rs
+++ b/route-rs-runtime/src/link/primitive/fork_link.rs
@@ -23,14 +23,10 @@ impl<Packet: Clone + Send> ForkLink<Packet> {
     }
 
     /// Changes queue_capacity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "queue_capacity: {}, must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("queue_capacity: {}, must be > 0", queue_capacity)
         );
 
         ForkLink {
@@ -42,11 +38,8 @@ impl<Packet: Clone + Send> ForkLink<Packet> {
 
     pub fn num_egressors(self, num_egressors: usize) -> Self {
         assert!(
-            (1..=1000).contains(&num_egressors),
-            format!(
-                "num_egressors: {}, must be in range 1..=1000",
-                num_egressors
-            )
+            num_egressors > 0,
+            format!("num_egressors: {}, must be > 0", num_egressors)
         );
 
         ForkLink {

--- a/route-rs-runtime/src/link/primitive/fork_link.rs
+++ b/route-rs-runtime/src/link/primitive/fork_link.rs
@@ -55,14 +55,6 @@ impl<Packet: Clone + Send> ForkLink<Packet> {
             num_egressors: Some(num_egressors),
         }
     }
-
-    pub fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
-        ForkLink {
-            in_stream: Some(in_stream),
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
-    }
 }
 
 impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for ForkLink<Packet> {
@@ -72,8 +64,25 @@ impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for ForkLink<Pa
             1,
             "ForkLinks may only take one input stream!"
         );
+
+        if self.in_stream.is_some() {
+            panic!("ForkLink may only take 1 input stream")
+        }
+
         ForkLink {
             in_stream: Some(in_streams.remove(0)),
+            queue_capacity: self.queue_capacity,
+            num_egressors: self.num_egressors,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("ForkLink may only take 1 input stream")
+        }
+
+        ForkLink {
+            in_stream: Some(in_stream),
             queue_capacity: self.queue_capacity,
             num_egressors: self.num_egressors,
         }

--- a/route-rs-runtime/src/link/primitive/input_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/input_channel_link.rs
@@ -26,6 +26,10 @@ impl<Packet: Send + 'static> LinkBuilder<(), Packet> for InputChannelLink<Packet
         panic!("InputChannelLink does not take stream ingressors")
     }
 
+    fn ingressor(self, _in_stream: PacketStream<()>) -> Self {
+        panic!("InputChannelLink does not take any stream ingressors")
+    }
+
     fn build_link(self) -> Link<Packet> {
         if self.channel_receiver.is_none() {
             panic!("Cannot build link! Missing channel");

--- a/route-rs-runtime/src/link/primitive/join_link.rs
+++ b/route-rs-runtime/src/link/primitive/join_link.rs
@@ -36,9 +36,30 @@ impl<Packet: Send + Clone> JoinLink<Packet> {
             queue_capacity,
         }
     }
+}
+
+impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for JoinLink<Packet> {
+    fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
+        assert!(
+            in_streams.len() > 0,
+            format!(
+                "number of in_streams: {}, must be greater than 0",
+                in_streams.len()
+            )
+        );
+
+        if self.in_streams.is_some() {
+            panic!("Join link already has input streams")
+        }
+
+        JoinLink {
+            in_streams: Some(in_streams),
+            queue_capacity: self.queue_capacity,
+        }
+    }
 
     /// Appends the ingressor to the ingressors of the link.
-    pub fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
+    fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
         match self.in_streams {
             None => {
                 let in_streams = Some(vec![in_stream]);
@@ -54,22 +75,6 @@ impl<Packet: Send + Clone> JoinLink<Packet> {
                     queue_capacity: self.queue_capacity,
                 }
             }
-        }
-    }
-}
-
-impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for JoinLink<Packet> {
-    fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
-        assert!(
-            (1..=1000).contains(&in_streams.len()),
-            format!(
-                "number of in_streams: {}, must be in range 1..=1000",
-                in_streams.len()
-            )
-        );
-        JoinLink {
-            in_streams: Some(in_streams),
-            queue_capacity: self.queue_capacity,
         }
     }
 

--- a/route-rs-runtime/src/link/primitive/join_link.rs
+++ b/route-rs-runtime/src/link/primitive/join_link.rs
@@ -21,14 +21,10 @@ impl<Packet: Send + Clone> JoinLink<Packet> {
     }
 
     /// Changes queue_capacity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            (1..=1000).contains(&queue_capacity),
-            format!(
-                "Queue capacity: {}, must be in range 1..=1000",
-                queue_capacity
-            )
+            queue_capacity > 0,
+            format!("Queue capacity: {}, must be > 0", queue_capacity)
         );
 
         JoinLink {
@@ -41,7 +37,7 @@ impl<Packet: Send + Clone> JoinLink<Packet> {
 impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for JoinLink<Packet> {
     fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert!(
-            in_streams.len() > 0,
+            !in_streams.is_empty(),
             format!(
                 "number of in_streams: {}, must be greater than 0",
                 in_streams.len()
@@ -414,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Queue capacity: 0, must be in range 1..=1000")]
+    #[should_panic]
     fn empty_channel() {
         let mut input_streams: Vec<PacketStream<usize>> = Vec::new();
         input_streams.push(immediate_stream(vec![]));

--- a/route-rs-runtime/src/link/primitive/output_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/output_channel_link.rs
@@ -21,13 +21,6 @@ impl<Packet> OutputChannelLink<Packet> {
             channel_sender: Some(channel_sender),
         }
     }
-
-    pub fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
-        OutputChannelLink {
-            in_stream: Some(in_stream),
-            channel_sender: self.channel_sender,
-        }
-    }
 }
 
 impl<Packet: Send + 'static> LinkBuilder<Packet, ()> for OutputChannelLink<Packet> {
@@ -38,8 +31,22 @@ impl<Packet: Send + 'static> LinkBuilder<Packet, ()> for OutputChannelLink<Packe
             "OutputChannelLink may only take 1 input stream"
         );
 
+        if self.in_stream.is_some() {
+            panic!("OutputChannelLink may only take 1 input stream");
+        }
+
         OutputChannelLink {
             in_stream: Some(in_streams.remove(0)),
+            channel_sender: self.channel_sender,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("OutputChannelLink may only take 1 input stream");
+        }
+        OutputChannelLink {
+            in_stream: Some(in_stream),
             channel_sender: self.channel_sender,
         }
     }

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -15,13 +15,6 @@ impl<P: Processor> ProcessLink<P> {
             processor: None,
         }
     }
-
-    pub fn ingressor(self, in_stream: PacketStream<P::Input>) -> Self {
-        ProcessLink {
-            in_stream: Some(in_stream),
-            processor: self.processor,
-        }
-    }
 }
 
 /// Although `Link` allows an arbitrary number of ingressors and egressors, `ProcessLink`
@@ -36,8 +29,23 @@ impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for Process
             "ProcessLink may only take 1 input stream"
         );
 
+        if self.in_stream.is_some() {
+            panic!("ProcessLink may only take 1 input stream")
+        }
+
         ProcessLink {
             in_stream: Some(in_streams.remove(0)),
+            processor: self.processor,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<P::Input>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("ProcessLink may only take 1 input stream")
+        }
+
+        ProcessLink {
+            in_stream: Some(in_stream),
             processor: self.processor,
         }
     }

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -24,11 +24,10 @@ impl<P: Processor> QueueLink<P> {
     }
 
     /// Changes queue_capacity, default value is 10.
-    /// Valid range is 1..=1000
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
-            queue_capacity <= 1000,
-            format!("QueueLink capacity: {} > 1000", queue_capacity)
+            queue_capacity > 0,
+            format!("QueueLink queue capacity: {} must be > 0", queue_capacity)
         );
         assert_ne!(queue_capacity, 0, "queue capacity must be non-zero");
 
@@ -344,7 +343,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "queue capacity must be non-zero")]
+    #[should_panic]
     fn empty_channel() {
         let packets: Vec<i32> = vec![];
 

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -23,14 +23,6 @@ impl<P: Processor> QueueLink<P> {
         }
     }
 
-    pub fn ingressor(self, in_stream: PacketStream<P::Input>) -> Self {
-        QueueLink {
-            in_stream: Some(in_stream),
-            processor: self.processor,
-            queue_capacity: self.queue_capacity,
-        }
-    }
-
     /// Changes queue_capacity, default value is 10.
     /// Valid range is 1..=1000
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
@@ -56,8 +48,24 @@ impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for QueueLi
             "QueueLink may only take 1 input stream"
         );
 
+        if self.in_stream.is_some() {
+            panic!("QueueLink may only take 1 input stream")
+        }
+
         QueueLink {
             in_stream: Some(in_streams.remove(0)),
+            processor: self.processor,
+            queue_capacity: self.queue_capacity,
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<P::Input>) -> Self {
+        if self.in_stream.is_some() {
+            panic!("QueueLink may only take 1 input stream")
+        }
+
+        QueueLink {
+            in_stream: Some(in_stream),
             processor: self.processor,
             queue_capacity: self.queue_capacity,
         }


### PR DESCRIPTION
I've made ingressor a required function since every link already implemented it, essentially. I have also cemented the expected behavior of ingressor() and ingressors(). Namely that ingressor is a push operation. 

Also, as icing, I removed the limit that queue lengths and number of branches must be < 1000, cause I agree with Sam's argument that we should let users do what they want.

This doesn't change the function signature of ingressor so all the code still works. 