### PR TITLE
Codegen cleanup

### DIFF
--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -330,21 +330,6 @@ mod typedef {
     }
 }
 
-pub fn angle_bracketed_types(types: Vec<syn::Type>) -> syn::AngleBracketedGenericArguments {
-    syn::AngleBracketedGenericArguments {
-        colon2_token: None,
-        lt_token: syn::token::Lt {
-            spans: [fake_span()],
-        },
-        args: syn::punctuated::Punctuated::from_iter(
-            types.into_iter().map(syn::GenericArgument::Type),
-        ),
-        gt_token: syn::token::Gt {
-            spans: [fake_span()],
-        },
-    }
-}
-
 pub fn let_simple(
     identifier: syn::Ident,
     type_annotation: Option<syn::Type>,

--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -752,6 +752,15 @@ where
     })
 }
 
+pub fn stmt_expr_semi(expr: syn::Expr) -> syn::Stmt {
+    syn::Stmt::Semi(
+        expr,
+        syn::token::Semi {
+            spans: [fake_span()],
+        },
+    )
+}
+
 pub fn magic_newline() -> syn::Macro {
     syn::Macro {
         path: path(vec![(ident("graphgen_magic_newline"), None)]),

--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -761,6 +761,13 @@ pub fn stmt_expr_semi(expr: syn::Expr) -> syn::Stmt {
     )
 }
 
+pub fn type_tuple(types: Vec<syn::Type>) -> syn::Type {
+    syn::Type::Tuple(syn::TypeTuple {
+        paren_token: syn::token::Paren { span: fake_span() },
+        elems: syn::punctuated::Punctuated::from_iter(types.into_iter()),
+    })
+}
+
 pub fn magic_newline() -> syn::Macro {
     syn::Macro {
         path: path(vec![(ident("graphgen_magic_newline"), None)]),

--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -742,6 +742,16 @@ pub fn expr_match(input: syn::Expr, arms: Vec<(syn::Pat, syn::Expr)>) -> syn::Ex
     })
 }
 
+pub fn expr_lit_int<N>(number: N) -> syn::Expr
+where
+    N: std::string::ToString,
+{
+    syn::Expr::Lit(syn::ExprLit {
+        attrs: vec![],
+        lit: syn::Lit::Int(syn::LitInt::new(number.to_string().as_str(), fake_span())),
+    })
+}
+
 pub fn magic_newline() -> syn::Macro {
     syn::Macro {
         path: path(vec![(ident("graphgen_magic_newline"), None)]),

--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -718,6 +718,30 @@ pub fn expr_async(stmts: Vec<syn::Stmt>) -> syn::Expr {
     })
 }
 
+pub fn expr_match(input: syn::Expr, arms: Vec<(syn::Pat, syn::Expr)>) -> syn::Expr {
+    syn::Expr::Match(syn::ExprMatch {
+        attrs: vec![],
+        match_token: syn::token::Match { span: fake_span() },
+        expr: Box::new(input),
+        brace_token: syn::token::Brace { span: fake_span() },
+        arms: arms
+            .into_iter()
+            .map(|(pattern, expr)| syn::Arm {
+                attrs: vec![],
+                pat: pattern,
+                guard: None,
+                fat_arrow_token: syn::token::FatArrow {
+                    spans: [fake_span(), fake_span()],
+                },
+                body: Box::new(expr),
+                comma: Some(syn::token::Comma {
+                    spans: [fake_span()],
+                }),
+            })
+            .collect::<Vec<syn::Arm>>(),
+    })
+}
+
 pub fn magic_newline() -> syn::Macro {
     syn::Macro {
         path: path(vec![(ident("graphgen_magic_newline"), None)]),

--- a/route-rs-graphgen/src/codegen.rs
+++ b/route-rs-graphgen/src/codegen.rs
@@ -242,24 +242,6 @@ mod impl_struct {
     }
 }
 
-pub fn simple_path(segments: Vec<syn::Ident>, with_leading_colon: bool) -> syn::Path {
-    syn::Path {
-        leading_colon: if with_leading_colon {
-            Some(syn::token::Colon2 {
-                spans: [fake_span(), fake_span()],
-            })
-        } else {
-            None
-        },
-        segments: syn::punctuated::Punctuated::from_iter(segments.into_iter().map(|s| {
-            syn::PathSegment {
-                ident: s,
-                arguments: syn::PathArguments::None,
-            }
-        })),
-    }
-}
-
 /// Generates type declaration statements
 pub fn typedef(types: Vec<(syn::Ident, syn::Type)>) -> String {
     types
@@ -299,7 +281,7 @@ mod typedef {
                 ident("FooAsdfBar"),
                 syn::Type::Path(syn::TypePath {
                     qself: None,
-                    path: simple_path(vec![ident("usize")], false)
+                    path: path(vec![(ident("usize"), None)])
                 })
             )]),
             "type FooAsdfBar = usize ;"
@@ -314,14 +296,14 @@ mod typedef {
                     ident("FooAsdfBar"),
                     syn::Type::Path(syn::TypePath {
                         qself: None,
-                        path: simple_path(vec![ident("usize")], false)
+                        path: path(vec![(ident("usize"), None)])
                     })
                 ),
                 (
                     ident("BarAsdfFoo"),
                     syn::Type::Path(syn::TypePath {
                         qself: None,
-                        path: simple_path(vec![ident("isize")], false)
+                        path: path(vec![(ident("isize"), None)])
                     })
                 )
             ]),
@@ -377,7 +359,7 @@ pub fn expr_path_ident(id: &str) -> syn::Expr {
     syn::Expr::Path(syn::ExprPath {
         attrs: vec![],
         qself: None,
-        path: simple_path(vec![ident(id)], false),
+        path: path(vec![(ident(id), None)]),
     })
 }
 
@@ -387,7 +369,7 @@ pub fn builder(base: syn::Ident, setters: Vec<(syn::Ident, Vec<syn::Expr>)>) -> 
         func: Box::new(syn::Expr::Path(syn::ExprPath {
             attrs: vec![],
             qself: None,
-            path: simple_path(vec![base, ident("new")], false),
+            path: path(vec![(base, None), (ident("new"), None)]),
         })),
         paren_token: syn::token::Paren { span: fake_span() },
         args: Default::default(),
@@ -477,7 +459,7 @@ pub fn build_link(
             receiver: Box::new(syn::Expr::Path(syn::ExprPath {
                 attrs: vec![],
                 qself: None,
-                path: simple_path(vec![ident("all_runnables")], false),
+                path: path(vec![(ident("all_runnables"), None)]),
             })),
             dot_token: syn::token::Dot {
                 spans: [fake_span()],
@@ -496,10 +478,10 @@ pub fn build_link(
                     expr: Box::new(syn::Expr::Path(syn::ExprPath {
                         attrs: vec![],
                         qself: None,
-                        path: simple_path(
-                            vec![ident(format!("runnables_{}", &index).as_str())],
-                            false,
-                        ),
+                        path: path(vec![(
+                            ident(format!("runnables_{}", &index).as_str()),
+                            None,
+                        )]),
                     })),
                 },
             )]),
@@ -518,7 +500,10 @@ pub fn build_link(
                 receiver: Box::new(syn::Expr::Path(syn::ExprPath {
                     attrs: vec![],
                     qself: None,
-                    path: simple_path(vec![ident(format!("egressors_{}", &index).as_str())], false),
+                    path: path(vec![(
+                        ident(format!("egressors_{}", &index).as_str()),
+                        None,
+                    )]),
                 })),
                 dot_token: syn::token::Dot {
                     spans: [fake_span()],
@@ -542,7 +527,7 @@ pub fn vec(exprs: Vec<syn::Expr>) -> syn::Expr {
     syn::Expr::Macro(syn::ExprMacro {
         attrs: vec![],
         mac: syn::Macro {
-            path: simple_path(vec![ident("vec")], false),
+            path: path(vec![(ident("vec"), None)]),
             bang_token: syn::token::Bang {
                 spans: [fake_span()],
             },
@@ -735,7 +720,7 @@ pub fn expr_async(stmts: Vec<syn::Stmt>) -> syn::Expr {
 
 pub fn magic_newline() -> syn::Macro {
     syn::Macro {
-        path: simple_path(vec![ident("graphgen_magic_newline")], false),
+        path: path(vec![(ident("graphgen_magic_newline"), None)]),
         bang_token: syn::token::Bang {
             spans: [fake_span()],
         },

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -274,13 +274,7 @@ fn gen_link_decls(
                                                 .map(|(p, b)| {
                                                     (
                                                         syn::parse_str::<syn::Pat>(p).unwrap(),
-                                                        syn::Expr::Lit(syn::ExprLit {
-                                                            attrs: vec![],
-                                                            lit: syn::Lit::Int(syn::LitInt::new(
-                                                                b.as_str(),
-                                                                proc_macro2::Span::call_site(),
-                                                            )),
-                                                        }),
+                                                        codegen::expr_lit_int(b),
                                                     )
                                                 })
                                                 .collect(),
@@ -290,13 +284,7 @@ fn gen_link_decls(
                             ),
                             (
                                 codegen::ident("num_egressors"),
-                                vec![syn::Expr::Lit(syn::ExprLit {
-                                    attrs: vec![],
-                                    lit: syn::Lit::Int(syn::LitInt::new(
-                                        branches.len().to_string().as_str(),
-                                        proc_macro2::Span::call_site(),
-                                    )),
-                                })],
+                                vec![codegen::expr_lit_int(branches.len())],
                             ),
                         ],
                         branches.len(),

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -267,40 +267,24 @@ fn gen_link_decls(
                                             subpat: None,
                                         })],
                                         syn::ReturnType::Default,
-                                        vec![syn::Stmt::Expr(syn::Expr::Match(syn::ExprMatch {
-                                            attrs: vec![],
-                                            match_token: syn::token::Match {
-                                                span: proc_macro2::Span::call_site(),
-                                            },
-                                            expr: Box::new(codegen::expr_path_ident("c")),
-                                            brace_token: syn::token::Brace {
-                                                span: proc_macro2::Span::call_site(),
-                                            },
-                                            arms: match_branches
+                                        vec![syn::Stmt::Expr(codegen::expr_match(
+                                            codegen::expr_path_ident("c"),
+                                            match_branches
                                                 .into_iter()
-                                                .map(|(p, b)| syn::Arm {
-                                                    attrs: vec![],
-                                                    pat: syn::parse_str::<syn::Pat>(p).unwrap(),
-                                                    guard: None,
-                                                    fat_arrow_token: syn::token::FatArrow {
-                                                        spans: [
-                                                            proc_macro2::Span::call_site(),
-                                                            proc_macro2::Span::call_site(),
-                                                        ],
-                                                    },
-                                                    body: Box::new(syn::Expr::Lit(syn::ExprLit {
-                                                        attrs: vec![],
-                                                        lit: syn::Lit::Int(syn::LitInt::new(
-                                                            b.as_str(),
-                                                            proc_macro2::Span::call_site(),
-                                                        )),
-                                                    })),
-                                                    comma: Some(syn::token::Comma {
-                                                        spans: [proc_macro2::Span::call_site()],
-                                                    }),
+                                                .map(|(p, b)| {
+                                                    (
+                                                        syn::parse_str::<syn::Pat>(p).unwrap(),
+                                                        syn::Expr::Lit(syn::ExprLit {
+                                                            attrs: vec![],
+                                                            lit: syn::Lit::Int(syn::LitInt::new(
+                                                                b.as_str(),
+                                                                proc_macro2::Span::call_site(),
+                                                            )),
+                                                        }),
+                                                    )
                                                 })
-                                                .collect::<Vec<syn::Arm>>(),
-                                        }))],
+                                                .collect(),
+                                        ))],
                                     )],
                                 )],
                             ),

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -563,19 +563,7 @@ fn gen_run_body(
                 ))]),
             )]),
         })),
-        syn::Expr::Macro(syn::ExprMacro {
-            attrs: vec![],
-            mac: syn::Macro {
-                path: codegen::simple_path(vec![codegen::ident("vec")], false),
-                bang_token: syn::token::Bang {
-                    spans: [proc_macro2::Span::call_site()],
-                },
-                delimiter: syn::MacroDelimiter::Bracket(syn::token::Bracket {
-                    span: proc_macro2::Span::call_site(),
-                }),
-                tokens: proc_macro2::TokenStream::new(),
-            },
-        }),
+        codegen::vec(vec![]),
         true,
     ));
     let (mut processor_decls_stmts, processor_decls_map) = gen_processor_decls(&processors);

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -371,14 +371,9 @@ fn gen_tokio_run() -> Vec<syn::Stmt> {
                                     qself: None,
                                     path: codegen::path(vec![(
                                         codegen::ident("JoinHandle"),
-                                        Some(vec![syn::GenericArgument::Type(syn::Type::Tuple(
-                                            syn::TypeTuple {
-                                                paren_token: syn::token::Paren {
-                                                    span: proc_macro2::Span::call_site(),
-                                                },
-                                                elems: Default::default(),
-                                            },
-                                        ))]),
+                                        Some(vec![syn::GenericArgument::Type(
+                                            codegen::type_tuple(vec![]),
+                                        )]),
                                     )]),
                                 },
                             ))]),

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -14,7 +14,6 @@ use crate::pipeline_graph::{EdgeData, NodeData, NodeKind, PipelineGraph, XmlNode
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::iter::FromIterator;
 use syn::export::ToTokens;
 
 mod codegen;
@@ -554,21 +553,15 @@ fn gen_run_body(
         codegen::ident("all_runnables"),
         Some(syn::Type::Path(syn::TypePath {
             qself: None,
-            path: syn::Path {
-                leading_colon: None,
-                segments: syn::punctuated::Punctuated::from_iter(vec![syn::PathSegment {
-                    ident: codegen::ident("Vec"),
-                    arguments: syn::PathArguments::AngleBracketed(codegen::angle_bracketed_types(
-                        vec![syn::Type::Path(syn::TypePath {
-                            qself: None,
-                            path: codegen::simple_path(
-                                vec![codegen::ident("TokioRunnable")],
-                                false,
-                            ),
-                        })],
-                    )),
-                }]),
-            },
+            path: codegen::path(vec![(
+                codegen::ident("Vec"),
+                Some(vec![syn::GenericArgument::Type(syn::Type::Path(
+                    syn::TypePath {
+                        qself: None,
+                        path: codegen::path(vec![(codegen::ident("TokioRunnable"), None)]),
+                    },
+                ))]),
+            )]),
         })),
         syn::Expr::Macro(syn::ExprMacro {
             attrs: vec![],

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -357,85 +357,72 @@ fn gen_tokio_run() -> Vec<syn::Stmt> {
             ),
             true,
         )),
-        syn::Stmt::Semi(
-            codegen::call_function(
-                codegen::expr_field(codegen::expr_path_ident("rt"), "block_on"),
-                vec![codegen::expr_async(vec![
-                    syn::Stmt::Local(codegen::let_simple(
-                        codegen::ident("handles"),
-                        Some(syn::Type::Path(syn::TypePath {
-                            qself: None,
-                            path: codegen::path(vec![(
-                                codegen::ident("Vec"),
-                                Some(vec![syn::GenericArgument::Type(syn::Type::Path(
-                                    syn::TypePath {
-                                        qself: None,
-                                        path: codegen::path(vec![(
-                                            codegen::ident("JoinHandle"),
-                                            Some(vec![syn::GenericArgument::Type(
-                                                syn::Type::Tuple(syn::TypeTuple {
-                                                    paren_token: syn::token::Paren {
-                                                        span: proc_macro2::Span::call_site(),
-                                                    },
-                                                    elems: Default::default(),
-                                                }),
-                                            )]),
-                                        )]),
-                                    },
-                                ))]),
-                            )]),
-                        })),
-                        codegen::call_chain(
-                            codegen::expr_path_ident("all_runnables"),
-                            vec![
-                                ("into_iter", vec![]),
-                                (
-                                    "map",
-                                    vec![syn::Expr::Path(syn::ExprPath {
-                                        attrs: vec![],
-                                        qself: None,
-                                        path: codegen::path(vec![
-                                            (codegen::ident("tokio"), None),
-                                            (codegen::ident("spawn"), None),
-                                        ]),
-                                    })],
-                                ),
-                                ("collect", vec![]),
-                            ],
-                        ),
-                        false,
-                    )),
-                    codegen::for_loop(
-                        syn::Pat::Ident(syn::PatIdent {
-                            attrs: vec![],
-                            by_ref: None,
-                            mutability: None,
-                            ident: codegen::ident("handle"),
-                            subpat: None,
-                        }),
-                        codegen::expr_path_ident("handles"),
-                        vec![syn::Stmt::Semi(
-                            codegen::call_function(
-                                codegen::expr_field(
-                                    codegen::expr_field(
-                                        codegen::expr_path_ident("handle"),
-                                        "await",
-                                    ),
-                                    "unwrap",
-                                ),
-                                vec![],
+        codegen::stmt_expr_semi(codegen::call_function(
+            codegen::expr_field(codegen::expr_path_ident("rt"), "block_on"),
+            vec![codegen::expr_async(vec![
+                syn::Stmt::Local(codegen::let_simple(
+                    codegen::ident("handles"),
+                    Some(syn::Type::Path(syn::TypePath {
+                        qself: None,
+                        path: codegen::path(vec![(
+                            codegen::ident("Vec"),
+                            Some(vec![syn::GenericArgument::Type(syn::Type::Path(
+                                syn::TypePath {
+                                    qself: None,
+                                    path: codegen::path(vec![(
+                                        codegen::ident("JoinHandle"),
+                                        Some(vec![syn::GenericArgument::Type(syn::Type::Tuple(
+                                            syn::TypeTuple {
+                                                paren_token: syn::token::Paren {
+                                                    span: proc_macro2::Span::call_site(),
+                                                },
+                                                elems: Default::default(),
+                                            },
+                                        ))]),
+                                    )]),
+                                },
+                            ))]),
+                        )]),
+                    })),
+                    codegen::call_chain(
+                        codegen::expr_path_ident("all_runnables"),
+                        vec![
+                            ("into_iter", vec![]),
+                            (
+                                "map",
+                                vec![syn::Expr::Path(syn::ExprPath {
+                                    attrs: vec![],
+                                    qself: None,
+                                    path: codegen::path(vec![
+                                        (codegen::ident("tokio"), None),
+                                        (codegen::ident("spawn"), None),
+                                    ]),
+                                })],
                             ),
-                            syn::token::Semi {
-                                spans: [proc_macro2::Span::call_site()],
-                            },
-                        )],
+                            ("collect", vec![]),
+                        ],
                     ),
-                ])],
-            ),
-            syn::token::Semi {
-                spans: [proc_macro2::Span::call_site()],
-            },
-        ),
+                    false,
+                )),
+                codegen::for_loop(
+                    syn::Pat::Ident(syn::PatIdent {
+                        attrs: vec![],
+                        by_ref: None,
+                        mutability: None,
+                        ident: codegen::ident("handle"),
+                        subpat: None,
+                    }),
+                    codegen::expr_path_ident("handles"),
+                    vec![codegen::stmt_expr_semi(codegen::call_function(
+                        codegen::expr_field(
+                            codegen::expr_field(codegen::expr_path_ident("handle"), "await"),
+                            "unwrap",
+                        ),
+                        vec![],
+                    ))],
+                ),
+            ])],
+        )),
     ]
 }
 

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -120,10 +120,10 @@ fn gen_processor_decls(processors: &[&&NodeData]) -> (Vec<syn::Stmt>, HashMap<St
                     syn::Expr::Path(syn::ExprPath {
                         attrs: vec![],
                         qself: None,
-                        path: codegen::simple_path(
-                            vec![codegen::ident(&e.node_class), codegen::ident("new")],
-                            false,
-                        ),
+                        path: codegen::path(vec![
+                            (codegen::ident(&e.node_class), None),
+                            (codegen::ident("new"), None),
+                        ]),
                     }),
                     vec![],
                 ),
@@ -250,10 +250,10 @@ fn gen_link_decls(
                                     syn::Expr::Path(syn::ExprPath {
                                         attrs: vec![],
                                         qself: None,
-                                        path: codegen::simple_path(
-                                            vec![codegen::ident("Box"), codegen::ident("new")],
-                                            false,
-                                        ),
+                                        path: codegen::path(vec![
+                                            (codegen::ident("Box"), None),
+                                            (codegen::ident("new"), None),
+                                        ]),
                                     }),
                                     vec![codegen::closure(
                                         false,

--- a/route-rs-graphgen/src/main.rs
+++ b/route-rs-graphgen/src/main.rs
@@ -117,21 +117,17 @@ fn gen_processor_decls(processors: &[&&NodeData]) -> (Vec<syn::Stmt>, HashMap<St
             syn::Stmt::Local(codegen::let_simple(
                 codegen::ident(symbol.as_str()),
                 None,
-                syn::Expr::Call(syn::ExprCall {
-                    attrs: vec![],
-                    func: Box::new(syn::Expr::Path(syn::ExprPath {
+                codegen::call_function(
+                    syn::Expr::Path(syn::ExprPath {
                         attrs: vec![],
                         qself: None,
                         path: codegen::simple_path(
                             vec![codegen::ident(&e.node_class), codegen::ident("new")],
                             false,
                         ),
-                    })),
-                    paren_token: syn::token::Paren {
-                        span: proc_macro2::Span::call_site(),
-                    },
-                    args: syn::punctuated::Punctuated::new(),
-                }),
+                    }),
+                    vec![],
+                ),
                 false,
             ))
         })


### PR DESCRIPTION
This is a bunch of small commits that clean up our code generation. Some of it is just using the existing codegen functions in places where the raw `syn` objects are generated in `main.rs`, and some of it is writing new helpers. At the end, we have gotten rid of all of the instances of `proc_macro2::Span::call_site()` in `main.rs`, which feels much better.

Fair warning, theres a lot of cargo fmt churn in this one, so looking at the individual commits will be helpful to understand what's actually changing.