### PR TITLE
MVR: Skeleton for new router structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ members = [
     "examples/trivial-identity",
     "examples/dns-interceptor",
     "examples/minimal-static-router",
+    "examples/minimum-viable-router",
 #    "examples/local-dns-nat",
 ]

--- a/examples/minimum-viable-router/Cargo.toml
+++ b/examples/minimum-viable-router/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "minimum-viable-router"
+version = "0.1.0"
+authors = ["Sam Gruber <sam@scgruber.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+route-rs-runtime = { path = "../../route-rs-runtime" }
+route-rs-packets = { path = "../../route-rs-packets" }
+tokio = { version = "0.2", features = ["full"] }
+crossbeam = "0.7.2"

--- a/examples/minimum-viable-router/LICENSE
+++ b/examples/minimum-viable-router/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 route-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/minimum-viable-router/src/classifier/interface.rs
+++ b/examples/minimum-viable-router/src/classifier/interface.rs
@@ -1,0 +1,24 @@
+use crate::processor::{Interface, InterfaceTaggedPacket};
+use route_rs_runtime::classifier::Classifier;
+use std::marker::PhantomData;
+
+pub struct ClassifyByDestinationInterface<DataPacket: Send + Clone> {
+    phantom: PhantomData<DataPacket>,
+}
+
+impl<DataPacket: Send + Clone> ClassifyByDestinationInterface<DataPacket> {
+    pub fn new() -> Self {
+        ClassifyByDestinationInterface {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<DataPacket: Send + Clone> Classifier for ClassifyByDestinationInterface<DataPacket> {
+    type Packet = InterfaceTaggedPacket<DataPacket>;
+    type Class = Option<Interface>;
+
+    fn classify(&self, packet: &Self::Packet) -> Self::Class {
+        packet.dst_interface.clone()
+    }
+}

--- a/examples/minimum-viable-router/src/classifier/mod.rs
+++ b/examples/minimum-viable-router/src/classifier/mod.rs
@@ -1,0 +1,2 @@
+mod interface;
+pub use self::interface::*;

--- a/examples/minimum-viable-router/src/classifier/mod.rs
+++ b/examples/minimum-viable-router/src/classifier/mod.rs
@@ -1,2 +1,5 @@
 mod interface;
 pub use self::interface::*;
+
+mod protocol;
+pub use self::protocol::*;

--- a/examples/minimum-viable-router/src/classifier/protocol.rs
+++ b/examples/minimum-viable-router/src/classifier/protocol.rs
@@ -1,0 +1,30 @@
+use crate::processor::InterfaceTaggedPacket;
+use route_rs_packets::EthernetFrame;
+use route_rs_runtime::classifier::Classifier;
+
+#[allow(dead_code)]
+pub enum Protocol {
+    ARP,
+    NDP,
+    DHCP,
+    IPv4,
+    IPv6,
+    Unknown,
+}
+
+pub struct ClassifyByProtocol {}
+
+impl ClassifyByProtocol {
+    pub fn new() -> Self {
+        ClassifyByProtocol {}
+    }
+}
+
+impl Classifier for ClassifyByProtocol {
+    type Packet = InterfaceTaggedPacket<EthernetFrame>;
+    type Class = Protocol;
+
+    fn classify(&self, _packet: &Self::Packet) -> Self::Class {
+        Protocol::Unknown
+    }
+}

--- a/examples/minimum-viable-router/src/main.rs
+++ b/examples/minimum-viable-router/src/main.rs
@@ -3,6 +3,7 @@ use route_rs_runtime::link::primitive::{InputChannelLink, OutputChannelLink};
 use route_rs_runtime::link::{LinkBuilder, PacketStream, TokioRunnable};
 use tokio::task::JoinHandle;
 
+mod classifier;
 mod processor;
 mod route;
 

--- a/examples/minimum-viable-router/src/main.rs
+++ b/examples/minimum-viable-router/src/main.rs
@@ -3,6 +3,7 @@ use route_rs_runtime::link::primitive::{InputChannelLink, OutputChannelLink};
 use route_rs_runtime::link::{LinkBuilder, PacketStream, TokioRunnable};
 use tokio::task::JoinHandle;
 
+mod processor;
 mod route;
 
 fn main() {

--- a/examples/minimum-viable-router/src/main.rs
+++ b/examples/minimum-viable-router/src/main.rs
@@ -1,0 +1,85 @@
+use route_rs_packets::EthernetFrame;
+use route_rs_runtime::link::primitive::{InputChannelLink, OutputChannelLink};
+use route_rs_runtime::link::{LinkBuilder, PacketStream, TokioRunnable};
+use tokio::task::JoinHandle;
+
+mod route;
+
+fn main() {
+    let mut runtime = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let ingress_wan = crossbeam::channel::unbounded();
+    let ingress_lan = crossbeam::channel::unbounded();
+    let ingress_host = crossbeam::channel::unbounded();
+
+    let egress_wan = crossbeam::channel::unbounded();
+    let egress_lan = crossbeam::channel::unbounded();
+    let egress_host = crossbeam::channel::unbounded();
+
+    drop(ingress_wan.0);
+    drop(ingress_lan.0);
+    drop(ingress_host.0);
+
+    run_route(
+        vec![ingress_wan.1, ingress_lan.1, ingress_host.1],
+        vec![egress_wan.0, egress_lan.0, egress_host.0],
+        &mut runtime,
+        route::Route::new(),
+    );
+
+    assert_eq!(egress_wan.1.len(), 0, "Egress WAN is not empty");
+    assert_eq!(egress_lan.1.len(), 0, "Egress LAN is not empty");
+    assert_eq!(egress_host.1.len(), 0, "Egress Host is not empty");
+
+    println!("Congratulations! Your router successfully does nothing!")
+}
+
+// TODO: Move this to route-rs-runtime
+fn run_route(
+    ingressors: Vec<crossbeam::Receiver<EthernetFrame>>,
+    egressors: Vec<crossbeam::Sender<EthernetFrame>>,
+    runtime: &mut tokio::runtime::Runtime,
+    route: route::Route,
+) {
+    let mut all_runnables = vec![];
+
+    let (_, upstreams): (
+        Vec<Vec<TokioRunnable>>,
+        Vec<Vec<PacketStream<EthernetFrame>>>,
+    ) = ingressors
+        .into_iter()
+        .map(|receiver| InputChannelLink::new().channel(receiver).build_link())
+        .unzip();
+
+    let (mut route_runnables, downstreams) = route
+        .ingressors(upstreams.into_iter().flatten().collect())
+        .build_link();
+
+    all_runnables.append(&mut route_runnables);
+
+    let egressor_inputs = downstreams.into_iter().zip(egressors.into_iter());
+
+    let (egress_runnables, _): (Vec<Vec<TokioRunnable>>, Vec<Vec<PacketStream<_>>>) =
+        egressor_inputs
+            .map(|(ingressor, sender)| {
+                OutputChannelLink::new()
+                    .ingressor(ingressor)
+                    .channel(sender)
+                    .build_link()
+            })
+            .unzip();
+
+    all_runnables.append(&mut egress_runnables.into_iter().flatten().collect());
+
+    runtime.block_on(async {
+        let handles: Vec<JoinHandle<()>> = all_runnables.into_iter().map(tokio::spawn).collect();
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+    })
+}

--- a/examples/minimum-viable-router/src/processor/mod.rs
+++ b/examples/minimum-viable-router/src/processor/mod.rs
@@ -1,0 +1,2 @@
+mod tag_interface;
+pub use self::tag_interface::*;

--- a/examples/minimum-viable-router/src/processor/tag_interface.rs
+++ b/examples/minimum-viable-router/src/processor/tag_interface.rs
@@ -1,0 +1,81 @@
+use route_rs_runtime::processor::Processor;
+use std::marker::PhantomData;
+
+#[derive(Clone)]
+pub enum Interface {
+    /// The Wide Area Network above the router
+    WAN,
+    /// The Local Area Network below the router
+    LAN,
+    /// The Linux host system in which the router is running
+    Host,
+}
+
+#[derive(Clone)]
+pub struct InterfaceTaggedPacket<Packet: Send + Clone> {
+    /// The interface tag for where the packet came from. None if we don't know yet.
+    src_interface: Option<Interface>,
+    /// The interface tag for where the packet is going. None if we don't know yet.
+    dst_interface: Option<Interface>,
+    /// The actual data packet.
+    packet: Packet,
+}
+
+/// When receiving a packet from an interface, we want to tag it with that interface in order to
+/// keep track of where it came from for later routing decisions. In practical use we probably won't
+/// want to set up the destination interface at the beginning, but maybe we will so we can leave
+/// that in here too since we have to provision the field anyway.
+pub struct EncapInterfaceTags<Packet: Send + Clone> {
+    src_interface: Option<Interface>,
+    dst_interface: Option<Interface>,
+    phantom_packet: PhantomData<Packet>,
+}
+
+impl<Packet: Send + Clone> EncapInterfaceTags<Packet> {
+    pub fn new(
+        src_interface: Option<Interface>,
+        dst_interface: Option<Interface>,
+    ) -> EncapInterfaceTags<Packet> {
+        EncapInterfaceTags {
+            src_interface,
+            dst_interface,
+            phantom_packet: PhantomData,
+        }
+    }
+}
+
+impl<Packet: Send + Clone> Processor for EncapInterfaceTags<Packet> {
+    type Input = Packet;
+    type Output = InterfaceTaggedPacket<Packet>;
+
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        Some(InterfaceTaggedPacket {
+            src_interface: self.src_interface.clone(),
+            dst_interface: self.dst_interface.clone(),
+            packet,
+        })
+    }
+}
+
+/// When sending a packet back out, we need to unwrap all of the interface tags after we're done
+/// making routing decisions, so that we can hand just the packet to the actual interface.
+pub struct DecapInterfaceTags<Packet: Send + Clone> {
+    phantom_packet: PhantomData<Packet>,
+}
+
+impl<Packet: Send + Clone> DecapInterfaceTags<Packet> {
+    pub fn new() -> DecapInterfaceTags<Packet> {
+        DecapInterfaceTags {
+            phantom_packet: PhantomData,
+        }
+    }
+}
+
+impl<Packet: Send + Clone> Processor for DecapInterfaceTags<Packet> {
+    type Input = InterfaceTaggedPacket<Packet>;
+    type Output = Packet;
+
+    fn process(&mut self, tagged_packet: Self::Input) -> Option<Self::Output> {
+        Some(tagged_packet.packet)
+    }
+}

--- a/examples/minimum-viable-router/src/processor/tag_interface.rs
+++ b/examples/minimum-viable-router/src/processor/tag_interface.rs
@@ -14,11 +14,11 @@ pub enum Interface {
 #[derive(Clone)]
 pub struct InterfaceTaggedPacket<Packet: Send + Clone> {
     /// The interface tag for where the packet came from. None if we don't know yet.
-    src_interface: Option<Interface>,
+    pub src_interface: Option<Interface>,
     /// The interface tag for where the packet is going. None if we don't know yet.
-    dst_interface: Option<Interface>,
+    pub dst_interface: Option<Interface>,
     /// The actual data packet.
-    packet: Packet,
+    pub packet: Packet,
 }
 
 /// When receiving a packet from an interface, we want to tag it with that interface in order to

--- a/examples/minimum-viable-router/src/route.rs
+++ b/examples/minimum-viable-router/src/route.rs
@@ -1,5 +1,7 @@
+use crate::processor::{DecapInterfaceTags, EncapInterfaceTags, Interface};
 use route_rs_packets::EthernetFrame;
-use route_rs_runtime::link::{Link, LinkBuilder, PacketStream};
+use route_rs_runtime::link::primitive::ProcessLink;
+use route_rs_runtime::link::{Link, LinkBuilder, PacketStream, ProcessLinkBuilder};
 
 pub struct Route {
     in_streams: Option<Vec<PacketStream<EthernetFrame>>>,
@@ -36,13 +38,75 @@ impl LinkBuilder<EthernetFrame, EthernetFrame> for Route {
     }
 
     fn build_link(self) -> Link<EthernetFrame> {
-        assert!(
-            self.in_streams.is_some() && self.in_streams.unwrap().len() == 3,
-            "Must provide 3 input streams"
-        );
+        let in_stream_wan;
+        let in_stream_lan;
+        let in_stream_host;
+        match self.in_streams {
+            Some(mut streams) => {
+                assert_eq!(streams.len(), 3, "Must provide 3 input streams to Route");
+                in_stream_wan = streams.remove(0);
+                in_stream_lan = streams.remove(0);
+                in_stream_host = streams.remove(0);
+            }
+            None => panic!("Must provide some input streams to Route"),
+        }
 
         let mut all_runnables = vec![];
         let mut all_egressors = vec![];
+
+        // Encap from interfaces BEGIN
+        let encap_wan_src = EncapInterfaceTags::new(Some(Interface::WAN), None);
+        let encap_lan_src = EncapInterfaceTags::new(Some(Interface::LAN), None);
+        let encap_host_src = EncapInterfaceTags::new(Some(Interface::Host), None);
+
+        let (mut encap_wan_src_runnables, mut encap_wan_src_egressors) = ProcessLink::new()
+            .processor(encap_wan_src)
+            .ingressor(in_stream_wan)
+            .build_link();
+        all_runnables.append(&mut encap_wan_src_runnables);
+        let encap_wan_src_egressor_0 = encap_wan_src_egressors.remove(0);
+
+        let (mut encap_lan_src_runnables, mut encap_lan_src_egressors) = ProcessLink::new()
+            .processor(encap_lan_src)
+            .ingressor(in_stream_lan)
+            .build_link();
+        all_runnables.append(&mut encap_lan_src_runnables);
+        let encap_lan_src_egressor_0 = encap_lan_src_egressors.remove(0);
+
+        let (mut encap_host_src_runnables, mut encap_host_src_egressors) = ProcessLink::new()
+            .processor(encap_host_src)
+            .ingressor(in_stream_host)
+            .build_link();
+        all_runnables.append(&mut encap_host_src_runnables);
+        let encap_host_src_egressor_0 = encap_host_src_egressors.remove(0);
+        // Encap from interfaces END
+
+        // Decap to interfaces BEGIN
+        let decap_wan_dst = DecapInterfaceTags::new();
+        let decap_lan_dst = DecapInterfaceTags::new();
+        let decap_host_dst = DecapInterfaceTags::new();
+
+        let (mut decap_wan_dst_runnables, mut decap_wan_dst_egressors) = ProcessLink::new()
+            .processor(decap_wan_dst)
+            .ingressor(encap_wan_src_egressor_0)
+            .build_link();
+        all_runnables.append(&mut decap_wan_dst_runnables);
+        all_egressors.append(&mut decap_wan_dst_egressors);
+
+        let (mut decap_lan_dst_runnables, mut decap_lan_dst_egressors) = ProcessLink::new()
+            .processor(decap_lan_dst)
+            .ingressor(encap_lan_src_egressor_0)
+            .build_link();
+        all_runnables.append(&mut decap_lan_dst_runnables);
+        all_egressors.append(&mut decap_lan_dst_egressors);
+
+        let (mut decap_host_dst_runnables, mut decap_host_dst_egressors) = ProcessLink::new()
+            .processor(decap_host_dst)
+            .ingressor(encap_host_src_egressor_0)
+            .build_link();
+        all_runnables.append(&mut decap_host_dst_runnables);
+        all_egressors.append(&mut decap_host_dst_egressors);
+        // Decap to interfaces END
 
         (all_runnables, all_egressors)
     }

--- a/examples/minimum-viable-router/src/route.rs
+++ b/examples/minimum-viable-router/src/route.rs
@@ -1,0 +1,49 @@
+use route_rs_packets::EthernetFrame;
+use route_rs_runtime::link::{Link, LinkBuilder, PacketStream};
+
+pub struct Route {
+    in_streams: Option<Vec<PacketStream<EthernetFrame>>>,
+}
+
+impl Route {
+    pub fn new() -> Self {
+        Route { in_streams: None }
+    }
+}
+
+impl LinkBuilder<EthernetFrame, EthernetFrame> for Route {
+    fn ingressors(self, in_streams: Vec<PacketStream<EthernetFrame>>) -> Self {
+        assert_eq!(in_streams.len(), 3, "Wrong number of inputs to Route");
+
+        Route {
+            in_streams: Some(in_streams),
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<EthernetFrame>) -> Self {
+        match self.in_streams {
+            Some(mut streams) => {
+                assert!(streams.len() < 3, "May only provide 3 input streams");
+                streams.push(in_stream);
+                Route {
+                    in_streams: Some(streams),
+                }
+            }
+            None => Route {
+                in_streams: Some(vec![in_stream]),
+            },
+        }
+    }
+
+    fn build_link(self) -> Link<EthernetFrame> {
+        assert!(
+            self.in_streams.is_some() && self.in_streams.unwrap().len() == 3,
+            "Must provide 3 input streams"
+        );
+
+        let mut all_runnables = vec![];
+        let mut all_egressors = vec![];
+
+        (all_runnables, all_egressors)
+    }
+}

--- a/route-rs-runtime/src/link/primitive/black_hole_link.rs
+++ b/route-rs-runtime/src/link/primitive/black_hole_link.rs
@@ -1,0 +1,91 @@
+use crate::link::{Link, LinkBuilder, PacketStream};
+use futures::task::{Context, Poll};
+use futures::{Future, Stream};
+use std::pin::Pin;
+
+#[derive(Default)]
+pub struct BlackHoleLink<Input> {
+    in_stream: Option<PacketStream<Input>>,
+}
+
+impl<Input> BlackHoleLink<Input> {
+    pub fn new() -> Self {
+        BlackHoleLink { in_stream: None }
+    }
+}
+
+impl<Input: Send + Unpin + 'static> LinkBuilder<Input, ()> for BlackHoleLink<Input> {
+    fn ingressors(self, mut in_streams: Vec<PacketStream<Input>>) -> Self {
+        assert_eq!(
+            in_streams.len(),
+            1,
+            "BlackHoleLink may only take 1 input stream"
+        );
+        assert!(
+            self.in_stream.is_none(),
+            "BlackHoleLink may only take 1 input stream"
+        );
+
+        BlackHoleLink {
+            in_stream: Some(in_streams.remove(0)),
+        }
+    }
+
+    fn ingressor(self, in_stream: PacketStream<Input>) -> Self {
+        assert!(
+            self.in_stream.is_none(),
+            "BlackHoleLink may only take 1 input stream"
+        );
+
+        BlackHoleLink {
+            in_stream: Some(in_stream),
+        }
+    }
+
+    fn build_link(self) -> Link<()> {
+        assert!(
+            self.in_stream.is_some(),
+            "Cannot build link! Missing input stream"
+        );
+
+        let ingressor = BlackHoleIngressor::new(self.in_stream.unwrap());
+        (vec![Box::new(ingressor)], vec![])
+    }
+}
+
+pub struct BlackHoleIngressor<Input> {
+    input_stream: PacketStream<Input>,
+}
+
+impl<Input> BlackHoleIngressor<Input> {
+    fn new(input_stream: PacketStream<Input>) -> Self {
+        BlackHoleIngressor { input_stream }
+    }
+}
+
+impl<Input> Unpin for BlackHoleIngressor<Input> {}
+
+impl<Input> Future for BlackHoleIngressor<Input> {
+    type Output = ();
+
+    /// Implement Poll for Future for BlackHoleIngressor
+    ///
+    /// This function accepts and ignores all packets from its input queue, until it cannot make
+    /// any forward progress, at which point it returns a NotReady and waits for the stream to send
+    /// more packets. If we get a Ready(None), the upstream has stopped and so we can, too.
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        loop {
+            let input_packet_option: Option<Input> =
+                ready!(Pin::new(&mut self.input_stream).poll_next(cx));
+
+            match input_packet_option {
+                None => {
+                    return Poll::Ready(());
+                }
+                Some(_) => {
+                    // Do nothing, allowing the runtime to drop the packet
+                }
+            }
+        }
+    }
+}

--- a/route-rs-runtime/src/link/primitive/mod.rs
+++ b/route-rs-runtime/src/link/primitive/mod.rs
@@ -34,3 +34,7 @@ pub use self::input_channel_link::*;
 /// Takes a stream and converts it to a channel for output.
 mod output_channel_link;
 pub use self::output_channel_link::*;
+
+/// Takes a stream and drops everything from it.
+mod black_hole_link;
+pub use self::black_hole_link::*;

--- a/route-rs-runtime/src/processor/mod.rs
+++ b/route-rs-runtime/src/processor/mod.rs
@@ -19,6 +19,9 @@ pub use self::drop::*;
 mod dec_ip_hop;
 pub use self::dec_ip_hop::*;
 
+mod trace;
+pub use self::trace::*;
+
 pub trait Processor {
     type Input: Send + Clone;
     type Output: Send + Clone;

--- a/route-rs-runtime/src/processor/trace.rs
+++ b/route-rs-runtime/src/processor/trace.rs
@@ -1,0 +1,26 @@
+use crate::processor::Processor;
+use std::marker::PhantomData;
+
+/// Processor that logs packets flowing through it
+#[derive(Default)]
+pub struct Trace<A: Send + Clone> {
+    phantom: PhantomData<A>,
+}
+
+impl<A: Send + Clone> Trace<A> {
+    pub fn new() -> Trace<A> {
+        Trace {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A: Send + Clone> Processor for Trace<A> {
+    type Input = A;
+    type Output = A;
+
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        // TODO: Write trace logs somewhere
+        Some(packet)
+    }
+}


### PR DESCRIPTION
This commit defines the basic structure for making a router using the
new framework with tokio 0.2.

In main() we create:
  - ingressors
  - egressors
  - tokio runtime
  - Route instance

We then pass these to run_route() to wire everything together and
initiate the tokio threads. run_route() should be moved into
route-rs-runtime before all of this is actually merged, since it's
pretty generic over any route link.

Since we don't have af_packet integrated with links yet, we're still
setting up InputChannelLink and OutputChannelLink at either end of
the router. This new framework does handle multiple inputs and output
channels, though.

While this does compile, it probably won't run because a lot of things
are left empty. I'll fill them in with reasonable defaults before this
is merged. A following commit will implement the top-level internals
of the minimum viable router, and then a further commit will convert
graphgen and the other examples into this style.