### PR TITLE
Router builder for generic I/O links

### DIFF
--- a/examples/minimal-static-router/src/main.rs
+++ b/examples/minimal-static-router/src/main.rs
@@ -56,15 +56,13 @@ pub struct Router {
     in_streams: Option<Vec<PacketStream<EthernetFrame>>>,
 }
 
-impl Router {
-    pub fn new() -> Self {
-        Router { in_streams: None }
-    }
-}
-
 // Then we declare it is a link that take in EthernetFrames and outputs EthernetFrames
 // LinkBuilder is always generic, so we need to fill out EthernetFrame
 impl LinkBuilder<EthernetFrame, EthernetFrame> for Router {
+    fn new() -> Self {
+        Router { in_streams: None }
+    }
+
     fn ingressors(self, in_streams: Vec<PacketStream<EthernetFrame>>) -> Self {
         assert!(
             in_streams.len() == 1,

--- a/route-rs-runtime/src/link/composite/drop_link.rs
+++ b/route-rs-runtime/src/link/composite/drop_link.rs
@@ -13,14 +13,6 @@ pub struct DropLink<I> {
 }
 
 impl<I> DropLink<I> {
-    pub fn new() -> Self {
-        DropLink {
-            in_stream: None,
-            drop_chance: None,
-            seed: None,
-        }
-    }
-
     pub fn drop_chance(self, chance: f64) -> Self {
         DropLink {
             in_stream: self.in_stream,
@@ -39,6 +31,14 @@ impl<I> DropLink<I> {
 }
 
 impl<I: Send + Clone + 'static> LinkBuilder<I, I> for DropLink<I> {
+    fn new() -> Self {
+        DropLink {
+            in_stream: None,
+            drop_chance: None,
+            seed: None,
+        }
+    }
+
     fn ingressors(self, mut ingress_streams: Vec<PacketStream<I>>) -> Self {
         assert_eq!(
             ingress_streams.len(),

--- a/route-rs-runtime/src/link/composite/m_transform_n_link.rs
+++ b/route-rs-runtime/src/link/composite/m_transform_n_link.rs
@@ -14,16 +14,6 @@ pub struct MtransformNLink<P: Processor + Send> {
 }
 
 impl<P: Processor + Send> MtransformNLink<P> {
-    pub fn new() -> Self {
-        MtransformNLink {
-            in_streams: None,
-            processor: None,
-            join_queue_capacity: 10,
-            fork_queue_capacity: 10,
-            num_egressors: None,
-        }
-    }
-
     /// Changes join_queue_capcity, default value is 10.
     pub fn join_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
@@ -70,6 +60,16 @@ impl<P: Processor + Send> MtransformNLink<P> {
 }
 
 impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for MtransformNLink<P> {
+    fn new() -> Self {
+        MtransformNLink {
+            in_streams: None,
+            processor: None,
+            join_queue_capacity: 10,
+            fork_queue_capacity: 10,
+            num_egressors: None,
+        }
+    }
+
     fn ingressors(self, in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert!(
             !in_streams.is_empty(),

--- a/route-rs-runtime/src/link/composite/mton_link.rs
+++ b/route-rs-runtime/src/link/composite/mton_link.rs
@@ -12,15 +12,6 @@ pub struct MtoNLink<Packet: Sized + Send + Clone> {
 }
 
 impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
-    pub fn new() -> Self {
-        MtoNLink {
-            in_streams: None,
-            join_queue_capacity: 10,
-            fork_queue_capacity: 10,
-            num_egressors: None,
-        }
-    }
-
     /// Changes join_queue_capcity, default value is 10.
     pub fn join_queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
@@ -67,6 +58,15 @@ impl<Packet: Sized + Send + Clone> MtoNLink<Packet> {
 }
 
 impl<Packet: Sized + Send + Clone + 'static> LinkBuilder<Packet, Packet> for MtoNLink<Packet> {
+    fn new() -> Self {
+        MtoNLink {
+            in_streams: None,
+            join_queue_capacity: 10,
+            fork_queue_capacity: 10,
+            num_egressors: None,
+        }
+    }
+
     fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert!(
             !in_streams.is_empty(),

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -39,6 +39,10 @@ pub type Link<Output> = (Vec<TokioRunnable>, Vec<PacketStream<Output>>);
 /// The two type parameters, Input and Output, refer to the input and output types of the Link.
 /// You can tell because the ingress/egress streams are of type `PacketStream<Input>`/`PacketStream<Output>` respectively.
 pub trait LinkBuilder<Input, Output> {
+    /// This is a builder struct, so we want to initialize without any parameters, and then pass
+    /// each of our arguments in dedicated builder methods.
+    fn new() -> Self;
+
     /// Links need a way to receive input from upstream.
     /// Some Links such as `ProcessLink` will only need at most 1, but others can accept many.
     /// Links that can not support the number of ingressors provided will panic. Links that already have

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -65,10 +65,14 @@ pub trait ProcessLinkBuilder<P: Processor>: LinkBuilder<P::Input, P::Output> {
     fn processor(self, processor: P) -> Self;
 }
 
-pub trait IngressLinkBuilder<Packet, Receiver>: LinkBuilder<(), Packet> {
-    fn channel(self, receiver: Receiver) -> Self;
+pub trait IngressLinkBuilder<Packet>: LinkBuilder<(), Packet> {
+    type Receiver;
+
+    fn channel(self, receiver: Self::Receiver) -> Self;
 }
 
-pub trait EgressLinkBuilder<Packet, Sender>: LinkBuilder<Packet, ()> {
-    fn channel(self, sender: Sender) -> Self;
+pub trait EgressLinkBuilder<Packet>: LinkBuilder<Packet, ()> {
+    type Sender;
+
+    fn channel(self, sender: Self::Sender) -> Self;
 }

--- a/route-rs-runtime/src/link/mod.rs
+++ b/route-rs-runtime/src/link/mod.rs
@@ -64,3 +64,11 @@ pub trait LinkBuilder<Input, Output> {
 pub trait ProcessLinkBuilder<P: Processor>: LinkBuilder<P::Input, P::Output> {
     fn processor(self, processor: P) -> Self;
 }
+
+pub trait IngressLinkBuilder<Packet, Receiver>: LinkBuilder<(), Packet> {
+    fn channel(self, receiver: Receiver) -> Self;
+}
+
+pub trait EgressLinkBuilder<Packet, Sender>: LinkBuilder<Packet, ()> {
+    fn channel(self, sender: Sender) -> Self;
+}

--- a/route-rs-runtime/src/link/primitive/classify_link.rs
+++ b/route-rs-runtime/src/link/primitive/classify_link.rs
@@ -20,16 +20,6 @@ pub struct ClassifyLink<C: Classifier> {
 }
 
 impl<C: Classifier> ClassifyLink<C> {
-    pub fn new() -> Self {
-        ClassifyLink {
-            in_stream: None,
-            classifier: None,
-            dispatcher: None,
-            queue_capacity: 10,
-            num_egressors: None,
-        }
-    }
-
     pub fn classifier(self, classifier: C) -> Self {
         ClassifyLink {
             in_stream: self.in_stream,
@@ -83,6 +73,16 @@ impl<C: Classifier> ClassifyLink<C> {
 }
 
 impl<C: Classifier + Send + 'static> LinkBuilder<C::Packet, C::Packet> for ClassifyLink<C> {
+    fn new() -> Self {
+        ClassifyLink {
+            in_stream: None,
+            classifier: None,
+            dispatcher: None,
+            queue_capacity: 10,
+            num_egressors: None,
+        }
+    }
+
     fn ingressors(self, mut in_streams: Vec<PacketStream<C::Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),

--- a/route-rs-runtime/src/link/primitive/fork_link.rs
+++ b/route-rs-runtime/src/link/primitive/fork_link.rs
@@ -16,14 +16,6 @@ pub struct ForkLink<Packet: Clone + Send> {
 }
 
 impl<Packet: Clone + Send> ForkLink<Packet> {
-    pub fn new() -> Self {
-        ForkLink {
-            in_stream: None,
-            queue_capacity: 10,
-            num_egressors: None,
-        }
-    }
-
     /// Changes queue_capacity, default value is 10.
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
@@ -53,6 +45,14 @@ impl<Packet: Clone + Send> ForkLink<Packet> {
 }
 
 impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for ForkLink<Packet> {
+    fn new() -> Self {
+        ForkLink {
+            in_stream: None,
+            queue_capacity: 10,
+            num_egressors: None,
+        }
+    }
+
     fn ingressors(self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),

--- a/route-rs-runtime/src/link/primitive/input_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/input_channel_link.rs
@@ -1,4 +1,4 @@
-use crate::link::{Link, LinkBuilder, PacketStream};
+use crate::link::{IngressLinkBuilder, Link, LinkBuilder, PacketStream};
 use crossbeam::crossbeam_channel;
 use futures::prelude::*;
 use futures::task::{Context, Poll};
@@ -9,8 +9,11 @@ pub struct InputChannelLink<Packet> {
     channel_receiver: Option<crossbeam::Receiver<Packet>>,
 }
 
-impl<Packet> InputChannelLink<Packet> {
-    pub fn channel(self, channel_receiver: crossbeam::Receiver<Packet>) -> Self {
+impl<Packet: Send + 'static> IngressLinkBuilder<Packet> for InputChannelLink<Packet>
+{
+    type Receiver = crossbeam::Receiver<Packet>;
+
+    fn channel(self, channel_receiver: crossbeam::Receiver<Packet>) -> Self {
         InputChannelLink {
             channel_receiver: Some(channel_receiver),
         }

--- a/route-rs-runtime/src/link/primitive/input_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/input_channel_link.rs
@@ -10,12 +10,6 @@ pub struct InputChannelLink<Packet> {
 }
 
 impl<Packet> InputChannelLink<Packet> {
-    pub fn new() -> Self {
-        InputChannelLink {
-            channel_receiver: None,
-        }
-    }
-
     pub fn channel(self, channel_receiver: crossbeam::Receiver<Packet>) -> Self {
         InputChannelLink {
             channel_receiver: Some(channel_receiver),
@@ -24,6 +18,12 @@ impl<Packet> InputChannelLink<Packet> {
 }
 
 impl<Packet: Send + 'static> LinkBuilder<(), Packet> for InputChannelLink<Packet> {
+    fn new() -> Self {
+        InputChannelLink {
+            channel_receiver: None,
+        }
+    }
+
     fn ingressors(self, mut _in_streams: Vec<PacketStream<()>>) -> Self {
         panic!("InputChannelLink does not take stream ingressors")
     }

--- a/route-rs-runtime/src/link/primitive/join_link.rs
+++ b/route-rs-runtime/src/link/primitive/join_link.rs
@@ -15,13 +15,6 @@ pub struct JoinLink<Packet: Send + Clone> {
 }
 
 impl<Packet: Send + Clone> JoinLink<Packet> {
-    pub fn new() -> Self {
-        JoinLink {
-            in_streams: None,
-            queue_capacity: 10,
-        }
-    }
-
     /// Changes queue_capacity, default value is 10.
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
@@ -37,6 +30,13 @@ impl<Packet: Send + Clone> JoinLink<Packet> {
 }
 
 impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for JoinLink<Packet> {
+    fn new() -> Self {
+        JoinLink {
+            in_streams: None,
+            queue_capacity: 10,
+        }
+    }
+
     fn ingressors(self, in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert!(
             !in_streams.is_empty(),

--- a/route-rs-runtime/src/link/primitive/output_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/output_channel_link.rs
@@ -10,13 +10,6 @@ pub struct OutputChannelLink<Packet> {
 }
 
 impl<Packet> OutputChannelLink<Packet> {
-    pub fn new() -> Self {
-        OutputChannelLink {
-            in_stream: None,
-            channel_sender: None,
-        }
-    }
-
     pub fn channel(self, channel_sender: crossbeam::Sender<Packet>) -> Self {
         OutputChannelLink {
             in_stream: self.in_stream,
@@ -26,6 +19,13 @@ impl<Packet> OutputChannelLink<Packet> {
 }
 
 impl<Packet: Send + 'static> LinkBuilder<Packet, ()> for OutputChannelLink<Packet> {
+    fn new() -> Self {
+        OutputChannelLink {
+            in_stream: None,
+            channel_sender: None,
+        }
+    }
+
     fn ingressors(self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),

--- a/route-rs-runtime/src/link/primitive/output_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/output_channel_link.rs
@@ -1,4 +1,4 @@
-use crate::link::{Link, LinkBuilder, PacketStream};
+use crate::link::{EgressLinkBuilder, Link, LinkBuilder, PacketStream};
 use futures::prelude::*;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
@@ -9,8 +9,11 @@ pub struct OutputChannelLink<Packet> {
     channel_sender: Option<crossbeam::Sender<Packet>>,
 }
 
-impl<Packet> OutputChannelLink<Packet> {
-    pub fn channel(self, channel_sender: crossbeam::Sender<Packet>) -> Self {
+impl<Packet: Send + 'static> EgressLinkBuilder<Packet> for OutputChannelLink<Packet>
+{
+    type Sender = crossbeam::Sender<Packet>;
+
+    fn channel(self, channel_sender: crossbeam::Sender<Packet>) -> Self {
         OutputChannelLink {
             in_stream: self.in_stream,
             channel_sender: Some(channel_sender),

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -13,19 +13,17 @@ pub struct ProcessLink<P: Processor> {
     processor: Option<P>,
 }
 
-impl<P: Processor> ProcessLink<P> {
-    pub fn new() -> Self {
+/// Although `Link` allows an arbitrary number of ingressors and egressors, `ProcessLink`
+/// may only have one ingress and egress stream since it lacks some kind of queue
+/// storage.
+impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for ProcessLink<P> {
+    fn new() -> Self {
         ProcessLink {
             in_stream: None,
             processor: None,
         }
     }
-}
 
-/// Although `Link` allows an arbitrary number of ingressors and egressors, `ProcessLink`
-/// may only have one ingress and egress stream since it lacks some kind of queue
-/// storage.
-impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for ProcessLink<P> {
     fn ingressors(self, mut in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert_eq!(
             in_streams.len(),

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -19,14 +19,6 @@ pub struct QueueLink<P: Processor> {
 }
 
 impl<P: Processor> QueueLink<P> {
-    pub fn new() -> Self {
-        QueueLink {
-            in_stream: None,
-            processor: None,
-            queue_capacity: 10,
-        }
-    }
-
     /// Changes queue_capacity, default value is 10.
     pub fn queue_capacity(self, queue_capacity: usize) -> Self {
         assert!(
@@ -44,6 +36,14 @@ impl<P: Processor> QueueLink<P> {
 }
 
 impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for QueueLink<P> {
+    fn new() -> Self {
+        QueueLink {
+            in_stream: None,
+            processor: None,
+            queue_capacity: 10,
+        }
+    }
+
     fn ingressors(self, mut in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert_eq!(
             in_streams.len(),

--- a/route-rs-runtime/src/utils/runner.rs
+++ b/route-rs-runtime/src/utils/runner.rs
@@ -1,4 +1,4 @@
-use crate::link::{Link, TokioRunnable};
+use crate::link::{EgressLinkBuilder, IngressLinkBuilder, Link, LinkBuilder, TokioRunnable};
 use crate::utils::test::packet_collectors::ExhaustiveCollector;
 use crossbeam::crossbeam_channel;
 use std::fmt::Debug;
@@ -56,5 +56,81 @@ pub fn runner<OutputPacket: Debug + Send + Clone + 'static>(
             .into_iter()
             .map(|receiver| receiver.iter().collect())
             .collect()
+    })
+}
+
+
+/// `build_and_run_router` is designed to assemble ingress and egress links for integrating to a
+/// variety of I/O implementations (e.g. af_packet, pcap, etc). This allows us to generically
+/// hook up a router for testing purposes without changing the internals.
+pub fn build_and_run_router<
+    IngressPacket,
+    IngressLink: IngressLinkBuilder<IngressPacket>,
+    EgressPacket,
+    EgressLink: EgressLinkBuilder<EgressPacket>,
+    Router: LinkBuilder<IngressPacket, EgressPacket>,
+>(
+    ingress_receivers: Vec<IngressLink::Receiver>,
+    egress_senders: Vec<EgressLink::Sender>,
+    router: Router,
+) {
+    let mut runtime = runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        // Create Ingress Links from the receivers
+        let ingressors = ingress_receivers
+            .into_iter()
+            .map(|r| IngressLink::new().channel(r).build_link())
+            .collect::<Vec<Link<IngressPacket>>>();
+
+        // Collapse runnables and egressors so that we can pass them along
+        let mut ingress_runnables = vec![];
+        let mut ingress_egressors = vec![];
+        ingressors
+            .into_iter()
+            .for_each(|(mut runnables, mut egressors)| {
+                ingress_runnables.append(&mut runnables);
+                ingress_egressors.append(&mut egressors);
+            });
+
+        // Set up the actual business logic router
+        let (mut router_runnables, router_egressors) =
+            router.ingressors(ingress_egressors).build_link();
+
+        // We know there should be a 1:1 correspondence between egressors from the router and senders,
+        // so we can zip them together and then build the egress links
+        let egressors = router_egressors
+            .into_iter()
+            .zip(egress_senders.into_iter())
+            .map(|(egressor, sender)| {
+                EgressLink::new()
+                    .ingressor(egressor)
+                    .channel(sender)
+                    .build_link()
+            })
+            .collect::<Vec<Link<()>>>();
+
+        // Egress links don't have any egressors, so all we need to do is pick up the runnables
+        let mut egress_runnables = vec![];
+        egressors
+            .into_iter()
+            .for_each(|(mut runnables, _egressors)| {
+                egress_runnables.append(&mut runnables);
+            });
+
+        let mut all_runnables = vec![];
+        all_runnables.append(&mut ingress_runnables);
+        all_runnables.append(&mut router_runnables);
+        all_runnables.append(&mut egress_runnables);
+
+        let handles: Vec<JoinHandle<()>> = all_runnables.into_iter().map(tokio::spawn).collect();
+        // 🏃💨💨
+        for handle in handles {
+            handle.await.unwrap();
+        }
     })
 }


### PR DESCRIPTION
This PR implements `build_and_run_router`, which allows us to generically hook up a router implementation to different kinds of I/O links. This should be useful for instance if we want to run a production router with af_packet but also run integration tests using saved pcaps. This runner method allows us to switch them out without changing the code for the router itself.

In order to genericize, we introduce `IngressLinkBuilder` and `EgressLinkBuilder` to capture the type conventions (Ingress has no input packet type; Egress has no output packet type), as well as methods and types to be used by `build_and_run_router`. We convert `InputChannelLink` and `OutputChannelLink` to match this trait, and observe that the current iteration of the af_packet links follows a similar pattern and should be easily converted.

A few tests are included to show expected usage.

Note that the type parameters to invoke are pretty gnarly. I couldn't figure out how to suppress more of them without adding more weird type requirements to the link implementation, but if somebody else has an idea I'm happy to try it out.