### PR TITLE
PHR: Rework Intake and Exhaust Links

### DIFF
--- a/examples/pi-home-router/src/interface/link/mod.rs
+++ b/examples/pi-home-router/src/interface/link/mod.rs
@@ -5,5 +5,6 @@ pub(crate) use self::interface_dispatch::InterfaceDispatch;
 mod interface_collect;
 #[allow(unused_imports)]
 pub(crate) use self::interface_collect::InterfaceCollect;
-//mod router_intake;
-//mod router_exhaust;
+
+mod router_exhaust;
+mod router_intake;

--- a/examples/pi-home-router/src/interface/link/router_exhaust.rs
+++ b/examples/pi-home-router/src/interface/link/router_exhaust.rs
@@ -1,101 +1,69 @@
-use crate::types::InterfaceAnnotated;
 use crate::interface::link::InterfaceDispatch;
-use route_rs_runtime::link::{LinkBuilder, PacketStream, Link};
-use route_rs_runtime::link::primitive::JoinLink;
+use crate::interface::processor::EthernetFrameToVec;
+use crate::types::InterfaceAnnotated;
 use route_rs_packets::EthernetFrame;
-use afpacket::SendHalf;
+use route_rs_runtime::link::primitive::{JoinLink, ProcessLink};
+use route_rs_runtime::link::ProcessLinkBuilder;
+use route_rs_runtime::link::{Link, LinkBuilder, PacketStream};
 
 /// RouterExhaust is a link that takes any number of input streams of
-/// InterfaceAnnotated<EthernetFrame>
+/// InterfaceAnnotated<EthernetFrame>s, and splits them into 3 outbound raw
+/// packet streams of Vec<u8>. The outbound streams should flow straight into
+/// the outbound interface link. The streams are in Host, LAN, WAN order.
+///
+/// Outbound:
+/// Port 0: Host
+/// Port 1: LAN
+/// Port 2: WAN
 pub(crate) struct RouterExhaust {
     in_streams: Option<Vec<PacketStream<InterfaceAnnotated<EthernetFrame>>>>,
-    host: Option<SendHalf>,
-    lan: Option<SendHalf>,
-    wan: Option<SendHalf>,
 }
 
 impl RouterExhaust {
     pub(crate) fn new() -> Self {
-        RouterExhaust {
-            in_streams: None,
-            host: None,
-            lan: None,
-            wan: None,
-        }
-    }
-
-    pub(crate) fn host(self, host: SendHalf) -> Self {
-        RouterExhaust {
-            in_streams: None,
-            host: Some(SendHalf),
-            lan: self.lan,
-            wan: self.wan,
-        }
-    }
-
-    pub(crate) fn lan(self, lan: &str) -> Self {
-        RouterExhaust {
-            in_streams: None,
-            host: self.host,
-            lan: Some(SendHalf),
-            wan: self.wan,
-        }
-    }
-
-    pub(crate) fn wan(self, wan: &str) -> Self {
-        RouterExhaust {
-            in_streams: None,
-            host: self.host,
-            lan: self.lan,
-            wan: Some(SendHalf),
-        }
+        RouterExhaust { in_streams: None }
     }
 }
 
-impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, ()>  for RouterExhaust {
-    fn ingressors(self, ingressors: Vec<PacketStream<InterfaceAnnotated<EthernetFrame>>>) -> RouterExhaust {
+impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, Vec<u8>> for RouterExhaust {
+    fn ingressors(
+        self,
+        ingressors: Vec<PacketStream<InterfaceAnnotated<EthernetFrame>>>,
+    ) -> RouterExhaust {
         assert!(!ingressors.is_empty(), "Ingressor vector is empty");
-        assert!(self.in_streams.is_none(), "RouterExhaust already has input_streams");
+        assert!(
+            self.in_streams.is_none(),
+            "RouterExhaust already has input_streams"
+        );
         RouterExhaust {
             in_streams: Some(ingressors),
-            host: self.host,
-            lan: self.lan,
-            wan: self.wan,
         }
     }
 
-
-    fn ingressor(self, ingressor: PacketStream<InterfaceAnnotated<EthernetFrame>>) -> RouterExhaust {
+    fn ingressor(
+        self,
+        ingressor: PacketStream<InterfaceAnnotated<EthernetFrame>>,
+    ) -> RouterExhaust {
         if self.in_streams.is_none() {
             return RouterExhaust {
                 in_streams: Some(vec![ingressor]),
-                host: self.host,
-                lan: self.lan,
-                wan: self.wan,
-            }
+            };
         } else {
-            self.in_streams.unwrap().push(ingressor);
+            let mut streams = self.in_streams.unwrap();
+            streams.push(ingressor);
             return RouterExhaust {
-                in_streams: self.in_streams,
-                host: self.host,
-                lan: self.lan,
-                wan: self.wan,
-            }
+                in_streams: Some(streams),
+            };
         }
     }
 
-    fn build_link(self) -> Link<InterfaceAnnotated<EthernetFrame>>  {
-        if self.host.is_none() {
-            panic!("Host interface was not provided")
-        } else if self.lan.is_none() {
-            panic!("LAN interface was not provided")
-        } else if self.wan.is_none() {
-            panic!("WAN Interface was not provided")
-        } else if self.in_streams.is_none() {
+    fn build_link(self) -> Link<Vec<u8>> {
+        if self.in_streams.is_none() {
             panic!("Input Streams were not provided")
         }
 
-        let all_runnables = vec![];
+        let mut all_runnables = vec![];
+        let mut interfaces = vec![];
 
         //---Join Inputs links---//
         let (mut join_runnables, join_egressors) = JoinLink::new()
@@ -109,26 +77,95 @@ impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, ()>  for RouterExhaust {
             .build_link();
         all_runnables.append(&mut dispatch_runnables);
 
-        //---Provide to Interfaces---//
-        // Host, Lan, Wan
-        let (mut host_runnables, _) = AfPacketOutputLink::new()
+        //---Create Raw streams---//
+        let (mut host_runnables, mut host_egressors) = ProcessLink::new()
             .ingressor(dispatch_egressors.remove(0))
-            .channel(self.host)
-            .build_link;
+            .processor(EthernetFrameToVec)
+            .build_link();
         all_runnables.append(&mut host_runnables);
+        interfaces.append(&mut host_egressors);
 
-        let (mut lan_runnables, _) = AfPacketOutputLink::new()
+        let (mut lan_runnables, mut lan_egressors) = ProcessLink::new()
             .ingressor(dispatch_egressors.remove(0))
-            .channel(self.lan)
-            .build_link;
+            .processor(EthernetFrameToVec)
+            .build_link();
         all_runnables.append(&mut lan_runnables);
+        interfaces.append(&mut lan_egressors);
 
-        let (mut wan_runnables, _) = AfPacketOutputLink::new()
+        let (mut wan_runnables, mut wan_egressors) = ProcessLink::new()
             .ingressor(dispatch_egressors.remove(0))
-            .channel(self.wan)
-            .build_link;
+            .processor(EthernetFrameToVec)
+            .build_link();
         all_runnables.append(&mut wan_runnables);
+        interfaces.append(&mut wan_egressors);
 
-        (all_runnables, ())
+        (all_runnables, interfaces)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Interface;
+    use route_rs_runtime::utils::test::harness::{initialize_runtime, test_link};
+    use route_rs_runtime::utils::test::packet_generators::immediate_stream;
+
+    #[test]
+    fn router_exhaust() {
+        let for_host = vec![
+            InterfaceAnnotated {
+                packet: EthernetFrame::empty(),
+                inbound_interface: Interface::Unmarked,
+                outbound_interface: Interface::Host,
+            };
+            3
+        ];
+        let mut for_lan = vec![
+            InterfaceAnnotated {
+                packet: EthernetFrame::empty(),
+                inbound_interface: Interface::Unmarked,
+                outbound_interface: Interface::Lan,
+            };
+            3
+        ];
+        let mut for_wan = vec![
+            InterfaceAnnotated {
+                packet: EthernetFrame::empty(),
+                inbound_interface: Interface::Unmarked,
+                outbound_interface: Interface::Wan,
+            };
+            3
+        ];
+        let mut unmarked = vec![
+            InterfaceAnnotated {
+                packet: EthernetFrame::empty(),
+                inbound_interface: Interface::Unmarked,
+                outbound_interface: Interface::Unmarked,
+            };
+            3
+        ];
+        let mut packets = for_host;
+        packets.append(&mut for_lan);
+        packets.append(&mut for_wan);
+        packets.append(&mut unmarked);
+
+        let mut runtime = initialize_runtime();
+        let results = runtime.block_on(async {
+            let link = RouterExhaust::new()
+                .ingressor(immediate_stream(packets.clone()))
+                .ingressor(immediate_stream(packets.clone()))
+                .ingressor(immediate_stream(packets))
+                .build_link();
+
+            test_link(link, None).await
+        });
+
+        let host = &results[0];
+        let lan = &results[1];
+        let wan = &results[2];
+
+        assert!(host.len() == 9, "Incorrect number of host packets");
+        assert!(lan.len() == 9, "Incorrenct number of lan packts");
+        assert!(wan.len() == 9, "Incorrect number of wan packets");
     }
 }

--- a/examples/pi-home-router/src/interface/link/router_intake.rs
+++ b/examples/pi-home-router/src/interface/link/router_intake.rs
@@ -1,119 +1,168 @@
-use crate::types::{InterfaceAnnotated, EtherType};
-use crate::interface::link::InterfaceCollect;
 use crate::interface::classifier::ByEtherType;
-use route_rs_runtime::link::{LinkBuilder, PacketStream, Link};
-use route_rs_runtime::link::primitive::ClassifyLink;
+use crate::interface::link::InterfaceCollect;
+use crate::interface::processor::VecToEthernetFrame;
+use crate::types::{EtherType, InterfaceAnnotated};
 use route_rs_packets::EthernetFrame;
-use afpacket::RecvHalf;
+use route_rs_runtime::link::primitive::{ClassifyLink, ProcessLink};
+use route_rs_runtime::link::ProcessLinkBuilder;
+use route_rs_runtime::link::{Link, LinkBuilder, PacketStream};
 
-/// RouterIntake is a link that takes no inputs and outputs 3 streams sorted by EtherType.
-/// Intake Manifold handles the creation of AFPacket links to generate packets from the 3 input interfaces
-/// (Host, LAN, WAN) and then collects and sorts them into 3 distinct output streams based.
+/// RouterIntake is a link that take in 3 streams from the interfaces of the PHR, combines them into
+/// a stream of packets. That stream is then divided into 3 output streams, by IP type. RouterIntake
+/// takes in raw Vec<u8> packets, and outputs InterfaceAnnotated<EthernetFrame> packets. Any packets
+/// that are not valid EthernetFrames, or are not of a supported EtherType (IPv4, IPv6, ARP) are
+/// dropped. Input streams should be provided in Host, LAN, WAN order.
 ///
-/// Outputs: 3 streams of same packet type
+/// Inputs:
+/// Port 0: Host
+/// Port 1: LAN
+/// Port 2: WAN
+///
+/// Outputs:
 /// Port 0: ARP
 /// Port 1: IPv4
 /// Port 2: IPv6
 pub(crate) struct RouterIntake {
-    host: Option<RecvHalf>,
-    lan: Option<RecvHalf>,
-    wan: Option<RecvHalf>,
+    in_streams: Option<Vec<PacketStream<Vec<u8>>>>,
 }
 
 impl RouterIntake {
     pub(crate) fn new() -> Self {
-        RouterIntake {
-            host: None,
-            lan: None,
-            wan: None,
-        }
-    }
-
-    pub(crate) fn host(self, host: RecvHalf) -> Self {
-        RouterIntake {
-            host: Some(RecvHalf),
-            lan: self.lan,
-            wan: self.wan,
-        }
-    }
-
-    pub(crate) fn lan(self, lan: &str) -> Self {
-        RouterIntake {
-            host: self.host,
-            lan: Some(RecvHalf),
-            wan: self.wan,
-        }
-    }
-
-    pub(crate) fn wan(self, wan: &str) -> Self {
-        RouterIntake {
-            host: self.host,
-            lan: self.lan,
-            wan: Some(RecvHalf),
-        }
+        RouterIntake { in_streams: None }
     }
 }
 
-impl LinkBuilder<(), InterfaceAnnotated<EthernetFrame>> for RouterIntake {
-    fn ingressors(self, ingressors: Vec<PacketStream<()>>) -> RouterIntake {
-        panic!("RouterIntakeManifold takes no inputs");
-    }
-
-    fn ingressor(self, ingressor: PacketStream<()>) -> RouterIntake {
-        panic!("RouterIntakeManifold takes no inputs");
-    }
-
-    fn build_link(self) -> Link<InterfaceAnnotated<EthernetFrame>>  {
-        if self.host.is_none() {
-            panic!("Host interface was not provided")
-        } else if self.lan.is_none() {
-            panic!("LAN interface was not provided")
-        } else if self.wan.is_none() {
-            panic!("WAN Interface was not provided")
+impl LinkBuilder<Vec<u8>, InterfaceAnnotated<EthernetFrame>> for RouterIntake {
+    fn ingressors(self, ingressors: Vec<PacketStream<Vec<u8>>>) -> RouterIntake {
+        if self.in_streams.is_some() {
+            panic!("RouterIntake: Double call of ingressors");
         }
+        if ingressors.len() != 3 {
+            panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
+        }
+        RouterIntake {
+            in_streams: Some(ingressors),
+        }
+    }
 
-        let all_runnables = vec![];
-        let interfaces = vec![];
+    fn ingressor(self, ingressor: PacketStream<Vec<u8>>) -> RouterIntake {
+        match self.in_streams {
+            Some(mut streams) => {
+                if streams.len() >= 3 {
+                    panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
+                }
+                streams.push(ingressor);
+                RouterIntake {
+                    in_streams: Some(streams),
+                }
+            }
+            None => RouterIntake {
+                in_streams: Some(vec![ingressor]),
+            },
+        }
+    }
 
-        //---Declare interface links---//
-        let (mut host_runnables, mut host_egressors) = AfPacketInputLink::new()
-            .channel(self.host)
+    fn build_link(self) -> Link<InterfaceAnnotated<EthernetFrame>> {
+        match &self.in_streams {
+            Some(streams) => {
+                if streams.len() != 3 {
+                    panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
+                }
+            }
+            None => {
+                panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
+            }
+        };
+
+        let mut streams = self.in_streams.unwrap();
+
+        let mut all_runnables = vec![];
+        let mut interfaces = vec![];
+
+        let (mut host_runnables, mut host_egressors) = ProcessLink::new()
+            .ingressor(streams.remove(0))
+            .processor(VecToEthernetFrame)
             .build_link();
         all_runnables.append(&mut host_runnables);
         interfaces.append(&mut host_egressors);
 
-        let (mut lan_runnables, mut lan_egressors) = AfPacketInputLink::new()
-            .channel(self.lan)
+        let (mut lan_runnables, mut lan_egressors) = ProcessLink::new()
+            .ingressor(streams.remove(0))
+            .processor(VecToEthernetFrame)
             .build_link();
         all_runnables.append(&mut lan_runnables);
         interfaces.append(&mut lan_egressors);
 
-        let (mut wan_runnables, mut wan_egressors) = AfPacketInputLink::new()
-            .channel(self.wan)
+        let (mut wan_runnables, mut wan_egressors) = ProcessLink::new()
+            .ingressor(streams.remove(0))
+            .processor(VecToEthernetFrame)
             .build_link();
         all_runnables.append(&mut wan_runnables);
         interfaces.append(&mut wan_egressors);
 
         //---Collect from Interfaces---//
-        let (mut collect_runnables, collect_egressors) = InterfaceCollect::new()
-            .ingressors(interfaces)
-            .build_link();
+        let (mut collect_runnables, collect_egressors) =
+            InterfaceCollect::new().ingressors(interfaces).build_link();
         all_runnables.append(&mut collect_runnables);
 
         //---Sort into streams by EtherType---//
         let (mut sort_runnables, sort_egressors) = ClassifyLink::new()
             .ingressors(collect_egressors)
             .num_egressors(3)
-            .classifier(ByEtherType)
-            .dispatcher(|class| match class {
+            .classifier(ByEtherType {})
+            .dispatcher(Box::new(|class| match class {
                 EtherType::ARP => Some(0),
                 EtherType::IPv4 => Some(1),
                 EtherType::IPv6 => Some(2),
                 EtherType::Unsupported => None,
-            })
+            }))
             .build_link();
         all_runnables.append(&mut sort_runnables);
 
         (all_runnables, sort_egressors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use route_rs_runtime::utils::test::harness::{initialize_runtime, test_link};
+    use route_rs_runtime::utils::test::packet_generators::immediate_stream;
+
+    #[test]
+    fn router_intake() {
+        let empty_frame = EthernetFrame::empty();
+        let mut arp_frame = empty_frame.clone();
+        arp_frame.set_ether_type(0x0806);
+        let mut ipv4_frame = empty_frame.clone();
+        ipv4_frame.set_ether_type(0x0800);
+        let mut ipv6_frame = empty_frame.clone();
+        ipv6_frame.set_ether_type(0x86DD);
+        let mut unsupported_frame = empty_frame.clone();
+        unsupported_frame.set_ether_type(0x1337);
+
+        let packets = vec![
+            arp_frame.data,
+            ipv4_frame.data,
+            ipv6_frame.clone().data,
+            unsupported_frame.data,
+            ipv6_frame.data,
+        ];
+
+        let host = immediate_stream(packets.clone());
+        let lan = immediate_stream(packets.clone());
+        let wan = immediate_stream(packets.clone());
+        let streams = vec![host, lan, wan];
+
+        let mut runtime = initialize_runtime();
+        let results = runtime.block_on(async {
+            let link = RouterIntake::new().ingressors(streams).build_link();
+
+            test_link(link, None).await
+        });
+
+        assert!(results[0].len() == 3, "Incorrect number of ARP packets");
+        assert!(results[1].len() == 3, "Incorrenct number of Ipv4 packts");
+        assert!(results[2].len() == 6, "Incorrect number of Ipv6 packets");
     }
 }

--- a/examples/pi-home-router/src/interface/processor/ethernetframe_to_vec.rs
+++ b/examples/pi-home-router/src/interface/processor/ethernetframe_to_vec.rs
@@ -1,0 +1,21 @@
+use route_rs_packets::EthernetFrame;
+use route_rs_runtime::processor::Processor;
+
+/// EthernetFrameToVec converts EthernetFrames into a raw Vec<u8>. This is done
+/// by stripping the data field out of the EthernetFrame structure.
+#[derive(Default)]
+pub(crate) struct EthernetFrameToVec;
+
+impl Processor for EthernetFrameToVec {
+    type Input = EthernetFrame;
+    type Output = Vec<u8>;
+
+    fn process(&mut self, mut packet: Self::Input) -> Option<Self::Output> {
+        if packet.layer2_offset == 0 {
+            //Save an allocation
+            Some(packet.data)
+        } else {
+            Some(packet.data.split_off(packet.layer2_offset))
+        }
+    }
+}

--- a/examples/pi-home-router/src/interface/processor/mod.rs
+++ b/examples/pi-home-router/src/interface/processor/mod.rs
@@ -3,3 +3,9 @@ pub(crate) use self::annotation_decap::InterfaceAnnotationDecap;
 
 mod annotation_encap;
 pub(crate) use self::annotation_encap::InterfaceAnnotationEncap;
+
+mod ethernetframe_to_vec;
+pub(crate) use self::ethernetframe_to_vec::EthernetFrameToVec;
+
+mod vec_to_ethernetframe;
+pub(crate) use self::vec_to_ethernetframe::VecToEthernetFrame;

--- a/examples/pi-home-router/src/interface/processor/vec_to_ethernetframe.rs
+++ b/examples/pi-home-router/src/interface/processor/vec_to_ethernetframe.rs
@@ -1,0 +1,19 @@
+use route_rs_packets::EthernetFrame;
+use route_rs_runtime::processor::Processor;
+
+/// VecToEthernetFrame converts a raw Vec<u8> buffer into an EthernetFrame packet. Any
+/// buffers that fail to parse into an EthernetFrame are dropped.
+#[derive(Default)]
+pub(crate) struct VecToEthernetFrame;
+
+impl Processor for VecToEthernetFrame {
+    type Input = Vec<u8>;
+    type Output = EthernetFrame;
+
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        match EthernetFrame::from_buffer(packet, 0) {
+            Ok(packet) => Some(packet),
+            Err(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
At our last meeting, other members brought up that we should not code
the IO layers into the business logic of our core router, particularly
since we want to be able to test the router using PCAPs, and swapping
real OS interfaces for PCAP streams shouldn't be a pain. So I am
reworking the intake and exhaust to not do this, and to handle
converting the raw Vec<u8> packet streams to route-rs Packets.

Note: This also makes the currently created interface sections no longer dependent on AfPacket.  I'll create a new link to handle creation and deletion of the AfPacket links once they are merged. Ideally we will be able to handle hooking up PCAPs the same way, so testing is simplified. 