### PR TITLE
travis.yml: Fix missing libpcap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 jobs:
   include:
     - stage: test
+      before_install: sudo apt-get update && sudo apt-get install -y libpcap-dev
       install: rustup component add rustfmt &&
                 rustup component add clippy &&
                 cargo install -f --version 0.3.0 cargo-deny


### PR DESCRIPTION
The pcap crate requires libpcap, so let's make sure that's installed in
our travis setup.