### PR TITLE
Draft: AutoEgressor, auto unpack egressor vector

### DIFF
--- a/examples/minimal-static-router/src/main.rs
+++ b/examples/minimal-static-router/src/main.rs
@@ -4,6 +4,7 @@ use route_rs_runtime::link::{
     Link, LinkBuilder, PacketStream, ProcessLinkBuilder,
 };
 use route_rs_runtime::utils::{runner::runner, test::packet_generators::immediate_stream};
+use route_rs_runtime::AutoEgressor;
 
 mod classifiers;
 mod processors;
@@ -160,19 +161,20 @@ impl LinkBuilder<EthernetFrame, EthernetFrame> for Router {
                     }))
                     .build_link();
             all_runnables.append(&mut ipv6_subnet_router_runnables);
+            AutoEgressor!(ipv6_subnet_router_egressors, sub_a, sub_b, sub_c);
 
             let (_, mut ipv6_encap_interface0_egressors) = ProcessLink::new()
-                .ingressor(ipv6_subnet_router_egressors.remove(0))
+                .ingressor(sub_a)
                 .processor(processors::Ipv6Encap)
                 .build_link();
 
             let (_, mut ipv6_encap_interface1_egressors) = ProcessLink::new()
-                .ingressor(ipv6_subnet_router_egressors.remove(0))
+                .ingressor(sub_b)
                 .processor(processors::Ipv6Encap)
                 .build_link();
 
             let (_, mut ipv6_encap_interface2_egressors) = ProcessLink::new()
-                .ingressor(ipv6_subnet_router_egressors.remove(0))
+                .ingressor(sub_c)
                 .processor(processors::Ipv6Encap)
                 .build_link();
 

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -1,5 +1,18 @@
 //! In brief: The runtime is what takes the basket of computation required by the user, links it together into the desired
 //! graph, and preps it to be handed to the Tokio for running.
+#[macro_export]
+macro_rules! AutoEgressor {
+    // Base case: 1 egressor
+    ($vector:ident, $x:ident) => {
+        let $x = $vector.remove(0);
+    };
+    // More than 1 egressor
+    ($vector:ident, $x:ident, $($y:ident),+) => {
+        let $x = $vector.remove(0);
+        AutoEgressor!($vector, $($y), +)
+    }
+}
+
 #[macro_use]
 extern crate futures;
 extern crate crossbeam;
@@ -19,3 +32,4 @@ pub mod pipeline;
 
 /// Utilities for the Runtime. Mostly testing constructs.
 pub mod utils;
+


### PR DESCRIPTION
This is a super trivial commit using a macro to auto unpack a the
egressor vector into a generic length set of variables. I bet with some
more clever thinking we could make something even more ergonomic, but I
wanted to at least demonstrate this is possible. The macro is quite
simple, checkout rust_by_example variadic functions for more.

The macro basically takes the name of the vector, and an unlimited length of identifiers to pull the values of the vector into. Under the hood it simply injects the remove() call, in a recursive manner. 

I don't think this one is ready for merge, maybe in person we can brainstorm what a better layout would look like, but this is pretty good for a 10 min whip up. 