### PR TITLE
General Builder Syntax improvements

### DIFF
--- a/examples/pi-home-router/src/interface/link/interface_collect.rs
+++ b/examples/pi-home-router/src/interface/link/interface_collect.rs
@@ -19,7 +19,7 @@ impl InterfaceCollect {
 }
 
 impl LinkBuilder<EthernetFrame, InterfaceAnnotated<EthernetFrame>> for InterfaceCollect {
-    fn ingressors(self, ingressors: Vec<PacketStream<EthernetFrame>>) -> InterfaceCollect {
+    fn ingressors(mut self, ingressors: Vec<PacketStream<EthernetFrame>>) -> Self {
         assert!(
             ingressors.len() == 3,
             "Link only supports 3 interfaces [Host: 0, Lan: 1, Wan: 2]"
@@ -28,24 +28,20 @@ impl LinkBuilder<EthernetFrame, InterfaceAnnotated<EthernetFrame>> for Interface
             panic!("Interface Mux: Double call of ingressors function");
         }
 
-        InterfaceCollect {
-            in_streams: Some(ingressors),
-        }
+        self.in_streams = Some(ingressors);
+        self
     }
 
-    fn ingressor(self, ingressor: PacketStream<EthernetFrame>) -> InterfaceCollect {
+    fn ingressor(mut self, ingressor: PacketStream<EthernetFrame>) -> Self {
         match self.in_streams {
             Some(mut streams) => {
                 assert!(streams.len() < 3, "Trying to add too many streams");
                 streams.push(ingressor);
-                InterfaceCollect {
-                    in_streams: Some(streams),
-                }
+                self.in_streams = Some(streams);
             }
-            None => InterfaceCollect {
-                in_streams: Some(vec![ingressor]),
-            },
+            None => self.in_streams = Some(vec![ingressor]),
         }
+        self
     }
 
     fn build_link(self) -> Link<InterfaceAnnotated<EthernetFrame>> {

--- a/examples/pi-home-router/src/interface/link/interface_dispatch.rs
+++ b/examples/pi-home-router/src/interface/link/interface_dispatch.rs
@@ -25,9 +25,9 @@ impl InterfaceDispatch {
 
 impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, EthernetFrame> for InterfaceDispatch {
     fn ingressors(
-        self,
+        mut self,
         mut in_streams: Vec<PacketStream<InterfaceAnnotated<EthernetFrame>>>,
-    ) -> InterfaceDispatch {
+    ) -> Self {
         assert!(
             in_streams.len() == 1,
             "InterfaceDispatch only takes one input stream"
@@ -38,22 +38,17 @@ impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, EthernetFrame> for Interface
         }
 
         let stream = in_streams.remove(0);
-        InterfaceDispatch {
-            in_stream: Some(stream),
-        }
+        self.in_stream = Some(stream);
+        self
     }
 
-    fn ingressor(
-        self,
-        in_stream: PacketStream<InterfaceAnnotated<EthernetFrame>>,
-    ) -> InterfaceDispatch {
+    fn ingressor(mut self, in_stream: PacketStream<InterfaceAnnotated<EthernetFrame>>) -> Self {
         if self.in_stream.is_some() {
             panic!("Double call of ingressors of InterfaceDeumx");
         }
 
-        InterfaceDispatch {
-            in_stream: Some(in_stream),
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<EthernetFrame> {

--- a/examples/pi-home-router/src/interface/link/router_exhaust.rs
+++ b/examples/pi-home-router/src/interface/link/router_exhaust.rs
@@ -28,34 +28,27 @@ impl RouterExhaust {
 
 impl LinkBuilder<InterfaceAnnotated<EthernetFrame>, Vec<u8>> for RouterExhaust {
     fn ingressors(
-        self,
+        mut self,
         ingressors: Vec<PacketStream<InterfaceAnnotated<EthernetFrame>>>,
-    ) -> RouterExhaust {
+    ) -> Self {
         assert!(!ingressors.is_empty(), "Ingressor vector is empty");
         assert!(
             self.in_streams.is_none(),
             "RouterExhaust already has input_streams"
         );
-        RouterExhaust {
-            in_streams: Some(ingressors),
-        }
+        self.in_streams = Some(ingressors);
+        self
     }
 
-    fn ingressor(
-        self,
-        ingressor: PacketStream<InterfaceAnnotated<EthernetFrame>>,
-    ) -> RouterExhaust {
+    fn ingressor(mut self, ingressor: PacketStream<InterfaceAnnotated<EthernetFrame>>) -> Self {
         if self.in_streams.is_none() {
-            RouterExhaust {
-                in_streams: Some(vec![ingressor]),
-            }
+            self.in_streams = Some(vec![ingressor]);
         } else {
             let mut streams = self.in_streams.unwrap();
             streams.push(ingressor);
-            RouterExhaust {
-                in_streams: Some(streams),
-            }
+            self.in_streams = Some(streams);
         }
+        self
     }
 
     fn build_link(self) -> Link<Vec<u8>> {

--- a/examples/pi-home-router/src/interface/link/router_intake.rs
+++ b/examples/pi-home-router/src/interface/link/router_intake.rs
@@ -34,33 +34,29 @@ impl RouterIntake {
 }
 
 impl LinkBuilder<Vec<u8>, InterfaceAnnotated<EthernetFrame>> for RouterIntake {
-    fn ingressors(self, ingressors: Vec<PacketStream<Vec<u8>>>) -> RouterIntake {
+    fn ingressors(mut self, ingressors: Vec<PacketStream<Vec<u8>>>) -> Self {
         if self.in_streams.is_some() {
             panic!("RouterIntake: Double call of ingressors");
         }
         if ingressors.len() != 3 {
             panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
         }
-        RouterIntake {
-            in_streams: Some(ingressors),
-        }
+        self.in_streams = Some(ingressors);
+        self
     }
 
-    fn ingressor(self, ingressor: PacketStream<Vec<u8>>) -> RouterIntake {
+    fn ingressor(mut self, ingressor: PacketStream<Vec<u8>>) -> Self {
         match self.in_streams {
             Some(mut streams) => {
                 if streams.len() >= 3 {
                     panic!("RouterIntake requires 3 input streams, Host LAN WAN, in that order");
                 }
                 streams.push(ingressor);
-                RouterIntake {
-                    in_streams: Some(streams),
-                }
+                self.in_streams = Some(streams);
             }
-            None => RouterIntake {
-                in_streams: Some(vec![ingressor]),
-            },
+            None => self.in_streams = Some(vec![ingressor]),
         }
+        self
     }
 
     fn build_link(self) -> Link<InterfaceAnnotated<EthernetFrame>> {

--- a/route-rs-packets/src/ethernet.rs
+++ b/route-rs-packets/src/ethernet.rs
@@ -50,20 +50,23 @@ impl EthernetFrame {
         MacAddr::new(bytes)
     }
 
-    pub fn set_dest_mac(&mut self, mac: MacAddr) {
+    pub fn set_dest_mac(&mut self, mac: MacAddr) -> &mut Self {
         self.data[..6].copy_from_slice(&mac.bytes[..6]);
+        self
     }
 
-    pub fn set_src_mac(&mut self, mac: MacAddr) {
+    pub fn set_src_mac(&mut self, mac: MacAddr) -> &mut Self {
         self.data[6..12].copy_from_slice(&mac.bytes[..6]);
+        self
     }
 
     pub fn ether_type(&self) -> u16 {
         u16::from_be_bytes(self.data[12..=13].try_into().unwrap())
     }
 
-    pub fn set_ether_type(&mut self, ether_type: u16) {
+    pub fn set_ether_type(&mut self, ether_type: u16) -> &mut Self {
         self.data[12..=13].copy_from_slice(&ether_type.to_be_bytes());
+        self
     }
 
     // This gives you a cow of a slice of the payload.
@@ -71,11 +74,12 @@ impl EthernetFrame {
         Cow::from(&self.data[self.payload_offset..])
     }
 
-    pub fn set_payload(&mut self, payload: &[u8]) {
+    pub fn set_payload(&mut self, payload: &[u8]) -> &mut Self {
         let payload_len = payload.len() as u16;
         self.data.truncate(self.payload_offset);
         self.data.reserve_exact(payload_len as usize);
         self.data.extend(payload);
+        self
     }
 
     pub fn encap_ipv4(ipv4: Ipv4Packet) -> EthernetFrame {

--- a/route-rs-packets/src/udp.rs
+++ b/route-rs-packets/src/udp.rs
@@ -83,8 +83,9 @@ impl<'packet> UdpSegment {
         )
     }
 
-    pub fn set_src_port(&mut self, port: u16) {
+    pub fn set_src_port(&mut self, port: u16) -> &mut Self {
         self.data[self.layer4_offset..=self.layer4_offset + 1].copy_from_slice(&port.to_be_bytes());
+        self
     }
 
     pub fn dest_port(&self) -> u16 {
@@ -95,9 +96,10 @@ impl<'packet> UdpSegment {
         )
     }
 
-    pub fn set_dest_port(&mut self, port: u16) {
+    pub fn set_dest_port(&mut self, port: u16) -> &mut Self {
         self.data[self.layer4_offset + 2..=self.layer4_offset + 3]
             .copy_from_slice(&port.to_be_bytes());
+        self
     }
 
     pub fn length(&self) -> u16 {
@@ -118,9 +120,10 @@ impl<'packet> UdpSegment {
 
     /// Manually set the checksum of UDP packet, this should be improved later to
     /// be calculated automatically.
-    pub fn set_checksum(&mut self, checksum: u16) {
+    pub fn set_checksum(&mut self, checksum: u16) -> &mut Self {
         self.data[self.layer4_offset + 6..=self.layer4_offset + 7]
-            .copy_from_slice(&checksum.to_be_bytes())
+            .copy_from_slice(&checksum.to_be_bytes());
+        self
     }
 
     pub fn payload(&self) -> Cow<[u8]> {
@@ -129,11 +132,12 @@ impl<'packet> UdpSegment {
 
     /// Set payload of UDP packet, does not change checksum.
     /// Don't forget to update the length field of the IP packet that contains this.
-    pub fn set_payload(&mut self, payload: &[u8]) {
+    pub fn set_payload(&mut self, payload: &[u8]) -> &mut Self {
         let payload_len = payload.len();
         self.data.truncate(self.payload_offset);
         self.data.reserve_exact(payload_len);
         self.data.extend(payload);
+        self
     }
 }
 

--- a/route-rs-runtime/src/link/composite/drop_link.rs
+++ b/route-rs-runtime/src/link/composite/drop_link.rs
@@ -21,25 +21,19 @@ impl<I> DropLink<I> {
         }
     }
 
-    pub fn drop_chance(self, chance: f64) -> Self {
-        DropLink {
-            in_stream: self.in_stream,
-            drop_chance: Some(chance),
-            seed: self.seed,
-        }
+    pub fn drop_chance(mut self, chance: f64) -> Self {
+        self.drop_chance = Some(chance);
+        self
     }
 
-    pub fn seed(self, int_seed: u64) -> Self {
-        DropLink {
-            in_stream: self.in_stream,
-            drop_chance: self.drop_chance,
-            seed: Some(int_seed),
-        }
+    pub fn seed(mut self, int_seed: u64) -> Self {
+        self.seed = Some(int_seed);
+        self
     }
 }
 
 impl<I: Send + Clone + 'static> LinkBuilder<I, I> for DropLink<I> {
-    fn ingressors(self, mut ingress_streams: Vec<PacketStream<I>>) -> Self {
+    fn ingressors(mut self, mut ingress_streams: Vec<PacketStream<I>>) -> Self {
         assert_eq!(
             ingress_streams.len(),
             1,
@@ -50,23 +44,17 @@ impl<I: Send + Clone + 'static> LinkBuilder<I, I> for DropLink<I> {
             panic!("DropLink can only take 1 input stream")
         }
 
-        DropLink {
-            in_stream: Some(ingress_streams.remove(0)),
-            drop_chance: self.drop_chance,
-            seed: self.seed,
-        }
+        self.in_stream = Some(ingress_streams.remove(0));
+        self
     }
 
-    fn ingressor(self, in_stream: PacketStream<I>) -> Self {
+    fn ingressor(mut self, in_stream: PacketStream<I>) -> Self {
         if self.in_stream.is_some() {
             panic!("DropLink can only take 1 input stream")
         }
 
-        DropLink {
-            in_stream: Some(in_stream),
-            drop_chance: self.drop_chance,
-            seed: self.seed,
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<I> {

--- a/route-rs-runtime/src/link/primitive/classify_link.rs
+++ b/route-rs-runtime/src/link/primitive/classify_link.rs
@@ -32,57 +32,37 @@ impl<C: Classifier> ClassifyLink<C> {
         }
     }
 
-    pub fn classifier(self, classifier: C) -> Self {
-        ClassifyLink {
-            in_stream: self.in_stream,
-            classifier: Some(classifier),
-            dispatcher: self.dispatcher,
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+    pub fn classifier(mut self, classifier: C) -> Self {
+        self.classifier = Some(classifier);
+        self
     }
 
-    pub fn dispatcher(self, dispatcher: Box<Dispatcher<'static, C::Class>>) -> Self {
-        ClassifyLink {
-            in_stream: self.in_stream,
-            classifier: self.classifier,
-            dispatcher: Some(dispatcher),
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+    pub fn dispatcher(mut self, dispatcher: Box<Dispatcher<'static, C::Class>>) -> Self {
+        self.dispatcher = Some(dispatcher);
+        self
     }
 
-    pub fn queue_capacity(self, queue_capacity: usize) -> Self {
+    pub fn queue_capacity(mut self, queue_capacity: usize) -> Self {
         assert!(
             queue_capacity > 0,
             format!("Queue capacity: {}, must be > 0", queue_capacity)
         );
-        ClassifyLink {
-            in_stream: self.in_stream,
-            classifier: self.classifier,
-            dispatcher: self.dispatcher,
-            queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.queue_capacity = queue_capacity;
+        self
     }
 
-    pub fn num_egressors(self, num_egressors: usize) -> Self {
+    pub fn num_egressors(mut self, num_egressors: usize) -> Self {
         assert!(
             num_egressors > 0,
             format!("num_egressors: {}, must be > 0", num_egressors)
         );
-        ClassifyLink {
-            in_stream: self.in_stream,
-            classifier: self.classifier,
-            dispatcher: self.dispatcher,
-            queue_capacity: self.queue_capacity,
-            num_egressors: Some(num_egressors),
-        }
+        self.num_egressors = Some(num_egressors);
+        self
     }
 }
 
 impl<C: Classifier + Send + 'static> LinkBuilder<C::Packet, C::Packet> for ClassifyLink<C> {
-    fn ingressors(self, mut in_streams: Vec<PacketStream<C::Packet>>) -> Self {
+    fn ingressors(mut self, mut in_streams: Vec<PacketStream<C::Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),
             1,
@@ -93,27 +73,17 @@ impl<C: Classifier + Send + 'static> LinkBuilder<C::Packet, C::Packet> for Class
             panic!("ClassifyLink may only take 1 input stream")
         }
 
-        ClassifyLink {
-            in_stream: Some(in_streams.remove(0)),
-            classifier: self.classifier,
-            dispatcher: self.dispatcher,
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.in_stream = Some(in_streams.remove(0));
+        self
     }
 
-    fn ingressor(self, in_stream: PacketStream<C::Packet>) -> Self {
+    fn ingressor(mut self, in_stream: PacketStream<C::Packet>) -> Self {
         if self.in_stream.is_some() {
             panic!("ClassifyLink may only take 1 input stream")
         }
 
-        ClassifyLink {
-            in_stream: Some(in_stream),
-            classifier: self.classifier,
-            dispatcher: self.dispatcher,
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<C::Packet> {

--- a/route-rs-runtime/src/link/primitive/fork_link.rs
+++ b/route-rs-runtime/src/link/primitive/fork_link.rs
@@ -25,35 +25,29 @@ impl<Packet: Clone + Send> ForkLink<Packet> {
     }
 
     /// Changes queue_capacity, default value is 10.
-    pub fn queue_capacity(self, queue_capacity: usize) -> Self {
+    pub fn queue_capacity(mut self, queue_capacity: usize) -> Self {
         assert!(
             queue_capacity > 0,
             format!("queue_capacity: {}, must be > 0", queue_capacity)
         );
 
-        ForkLink {
-            in_stream: self.in_stream,
-            queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.queue_capacity = queue_capacity;
+        self
     }
 
-    pub fn num_egressors(self, num_egressors: usize) -> Self {
+    pub fn num_egressors(mut self, num_egressors: usize) -> Self {
         assert!(
             num_egressors > 0,
             format!("num_egressors: {}, must be > 0", num_egressors)
         );
 
-        ForkLink {
-            in_stream: self.in_stream,
-            queue_capacity: self.queue_capacity,
-            num_egressors: Some(num_egressors),
-        }
+        self.num_egressors = Some(num_egressors);
+        self
     }
 }
 
 impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for ForkLink<Packet> {
-    fn ingressors(self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
+    fn ingressors(mut self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),
             1,
@@ -64,23 +58,17 @@ impl<Packet: Send + Clone + 'static> LinkBuilder<Packet, Packet> for ForkLink<Pa
             panic!("ForkLink may only take 1 input stream")
         }
 
-        ForkLink {
-            in_stream: Some(in_streams.remove(0)),
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.in_stream = Some(in_streams.remove(0));
+        self
     }
 
-    fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
+    fn ingressor(mut self, in_stream: PacketStream<Packet>) -> Self {
         if self.in_stream.is_some() {
             panic!("ForkLink may only take 1 input stream")
         }
 
-        ForkLink {
-            in_stream: Some(in_stream),
-            queue_capacity: self.queue_capacity,
-            num_egressors: self.num_egressors,
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<Packet> {

--- a/route-rs-runtime/src/link/primitive/input_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/input_channel_link.rs
@@ -16,10 +16,9 @@ impl<Packet> InputChannelLink<Packet> {
         }
     }
 
-    pub fn channel(self, channel_receiver: crossbeam::Receiver<Packet>) -> Self {
-        InputChannelLink {
-            channel_receiver: Some(channel_receiver),
-        }
+    pub fn channel(mut self, channel_receiver: crossbeam::Receiver<Packet>) -> Self {
+        self.channel_receiver = Some(channel_receiver);
+        self
     }
 }
 

--- a/route-rs-runtime/src/link/primitive/output_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/output_channel_link.rs
@@ -17,16 +17,14 @@ impl<Packet> OutputChannelLink<Packet> {
         }
     }
 
-    pub fn channel(self, channel_sender: crossbeam::Sender<Packet>) -> Self {
-        OutputChannelLink {
-            in_stream: self.in_stream,
-            channel_sender: Some(channel_sender),
-        }
+    pub fn channel(mut self, channel_sender: crossbeam::Sender<Packet>) -> Self {
+        self.channel_sender = Some(channel_sender);
+        self
     }
 }
 
 impl<Packet: Send + 'static> LinkBuilder<Packet, ()> for OutputChannelLink<Packet> {
-    fn ingressors(self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
+    fn ingressors(mut self, mut in_streams: Vec<PacketStream<Packet>>) -> Self {
         assert_eq!(
             in_streams.len(),
             1,
@@ -37,20 +35,16 @@ impl<Packet: Send + 'static> LinkBuilder<Packet, ()> for OutputChannelLink<Packe
             panic!("OutputChannelLink may only take 1 input stream");
         }
 
-        OutputChannelLink {
-            in_stream: Some(in_streams.remove(0)),
-            channel_sender: self.channel_sender,
-        }
+        self.in_stream = Some(in_streams.remove(0));
+        self
     }
 
-    fn ingressor(self, in_stream: PacketStream<Packet>) -> Self {
+    fn ingressor(mut self, in_stream: PacketStream<Packet>) -> Self {
         if self.in_stream.is_some() {
             panic!("OutputChannelLink may only take 1 input stream");
         }
-        OutputChannelLink {
-            in_stream: Some(in_stream),
-            channel_sender: self.channel_sender,
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<()> {

--- a/route-rs-runtime/src/link/primitive/pcap.rs
+++ b/route-rs-runtime/src/link/primitive/pcap.rs
@@ -53,26 +53,26 @@ impl FromPcap {
     pub fn new() -> Self {
         FromPcap::default()
     }
-    pub fn replay_mode(self, replay_mode: PcapReplayMode) -> Self {
-        FromPcap {
-            src_file: self.src_file,
-            replay_mode,
-        }
+
+    pub fn replay_mode(mut self, replay_mode: PcapReplayMode) -> Self {
+        self.replay_mode = replay_mode;
+        self
     }
-    pub fn src_file(self, src_file: String) -> Self {
-        FromPcap {
-            src_file: Some(src_file),
-            replay_mode: self.replay_mode,
-        }
+
+    pub fn src_file(mut self, src_file: String) -> Self {
+        self.src_file = Some(src_file);
+        self
     }
 }
 impl LinkBuilder<(), Vec<u8>> for FromPcap {
     fn ingressor(self, _in_stream: PacketStream<()>) -> Self {
         panic!("FromPcap takes NO input stream")
     }
+
     fn ingressors(self, _ingress_streams: Vec<PacketStream<()>>) -> Self {
         panic!("FromPcap takes NO input stream(s)")
     }
+
     fn build_link(self) -> Link<Vec<u8>> {
         if let Some(src_file) = self.src_file {
             let pcap_proc = FromPcapEggressor::new(src_file, self.replay_mode);

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -26,7 +26,7 @@ impl<P: Processor> ProcessLink<P> {
 /// may only have one ingress and egress stream since it lacks some kind of queue
 /// storage.
 impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for ProcessLink<P> {
-    fn ingressors(self, mut in_streams: Vec<PacketStream<P::Input>>) -> Self {
+    fn ingressors(mut self, mut in_streams: Vec<PacketStream<P::Input>>) -> Self {
         assert_eq!(
             in_streams.len(),
             1,
@@ -37,21 +37,17 @@ impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for Process
             panic!("ProcessLink may only take 1 input stream")
         }
 
-        ProcessLink {
-            in_stream: Some(in_streams.remove(0)),
-            processor: self.processor,
-        }
+        self.in_stream = Some(in_streams.remove(0));
+        self
     }
 
-    fn ingressor(self, in_stream: PacketStream<P::Input>) -> Self {
+    fn ingressor(mut self, in_stream: PacketStream<P::Input>) -> Self {
         if self.in_stream.is_some() {
             panic!("ProcessLink may only take 1 input stream")
         }
 
-        ProcessLink {
-            in_stream: Some(in_stream),
-            processor: self.processor,
-        }
+        self.in_stream = Some(in_stream);
+        self
     }
 
     fn build_link(self) -> Link<P::Output> {
@@ -67,11 +63,9 @@ impl<P: Processor + Send + 'static> LinkBuilder<P::Input, P::Output> for Process
 }
 
 impl<P: Processor + Send + 'static> ProcessLinkBuilder<P> for ProcessLink<P> {
-    fn processor(self, processor: P) -> Self {
-        ProcessLink {
-            in_stream: self.in_stream,
-            processor: Some(processor),
-        }
+    fn processor(mut self, processor: P) -> Self {
+        self.processor = Some(processor);
+        self
     }
 }
 


### PR DESCRIPTION
This does two things, it switches us over to a more sane way of writing builder functions, by modifying self, rather than creating a new Structure each time. I changed this in the runtime and the PHR example.

The second updates the Packets setter functions, to be chainable, which makes setting a bunch of settings in a row much less verbose.