### PR TITLE
Unpack!: A Macro to help you remove stuff from links

### DIFF
--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -5,6 +5,38 @@ extern crate futures;
 extern crate crossbeam;
 extern crate tokio;
 
+#[macro_export]
+macro_rules! unpack {
+    (let ($runnables_collect:ident, [$($y:ident), +]) = $link:expr;) => {
+        let (mut runnables, mut egressors) = { $link };
+        $runnables_collect.append(&mut runnables);
+        unpack!(HELPER egressors, $($y), +);
+    };
+
+    (let (_, [$($y:ident), +]) = $link:expr;) => {
+        let (_, mut egressors) = { $link };
+        unpack!(HELPER egressors, $($y), +);
+    };
+
+    (let ($runnables_collect:ident, $egressors_collect:ident) = $link:expr;) => {
+        let (mut runnables, $egressors_collect) = { $link };
+        $runnables_collect.append(&mut runnables);
+    };
+
+    (let ($runnables_collect:ident, mut $egressors_collect:ident) = $link:expr;) => {
+        let (mut runnables, mut $egressors_collect) = { $link };
+        $runnables_collect.append(&mut runnables);
+    };
+
+    (HELPER $vector:ident, $e:ident ) => {
+        let $e = $vector.remove(0);
+    };
+    (HELPER $vector:ident, $e:ident, $($y:ident), +) => {
+        let $e = $vector.remove(0);
+        unpack!(HELPER $vector, $($y), +)
+    };
+}
+
 /// Implement the basic transformations for packets in the router.
 pub mod processor;
 

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -1,7 +1,40 @@
 //! In brief: The runtime is what takes the basket of computation required by the user, links it together into the desired
 //! graph, and preps it to be handed to the Tokio for running.
 
+/// Implement the basic transformations for packets in the router.
+pub mod processor;
+
+/// Implement classification functions, helping the router decide to send a packet down route A,B,C..and so on.
+pub mod classifier;
+
+/// Wrappers around Processors and Classfiers, and implement all the movement of Packets through the Router.
+pub mod link;
+
+/// Structure meant to encapsulate a router as and input and output channel. Used by graphgen.
+pub mod pipeline;
+
+/// Utilities for the Runtime. Mostly testing constructs.
+pub mod utils;
+
 #[macro_export]
+/// unpack!: Easy Link egressor destructuring
+///
+/// This macro helps destructure the egressor vector returned by a call to build_link().
+///
+/// ```
+/// use route_rs_runtime::link::primitive::ForkLink;
+/// use route_rs_runtime::link::LinkBuilder;
+/// use route_rs_runtime::utils::test::packet_generators::immediate_stream;
+/// use route_rs_runtime::unpack;
+///
+/// unpack!(
+///    let (_, [a,b,c]) = ForkLink::new()
+///             .num_egressors(3)
+///             .ingressor(immediate_stream(vec![1,2,3]))
+///             .build_link();
+/// );
+///
+/// ```
 macro_rules! unpack {
     (let ($runnables_collect:ident, [$($y:ident), +]) = $link:expr;) => {
         let (mut runnables, mut egressors) = { $link };
@@ -32,18 +65,3 @@ macro_rules! unpack {
         unpack!(HELPER $vector, $($y), +)
     };
 }
-
-/// Implement the basic transformations for packets in the router.
-pub mod processor;
-
-/// Implement classification functions, helping the router decide to send a packet down route A,B,C..and so on.
-pub mod classifier;
-
-/// Wrappers around Processors and Classfiers, and implement all the movement of Packets through the Router.
-pub mod link;
-
-/// Structure meant to encapsulate a router as and input and output channel. Used by graphgen.
-pub mod pipeline;
-
-/// Utilities for the Runtime. Mostly testing constructs.
-pub mod utils;

--- a/route-rs-runtime/src/lib.rs
+++ b/route-rs-runtime/src/lib.rs
@@ -1,9 +1,5 @@
 //! In brief: The runtime is what takes the basket of computation required by the user, links it together into the desired
 //! graph, and preps it to be handed to the Tokio for running.
-#[macro_use]
-extern crate futures;
-extern crate crossbeam;
-extern crate tokio;
 
 #[macro_export]
 macro_rules! unpack {

--- a/route-rs-runtime/src/link/primitive/classify_link.rs
+++ b/route-rs-runtime/src/link/primitive/classify_link.rs
@@ -5,6 +5,7 @@ use crossbeam::atomic::AtomicCell;
 use crossbeam::crossbeam_channel;
 use crossbeam::crossbeam_channel::{Receiver, Sender};
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/route-rs-runtime/src/link/primitive/fork_link.rs
+++ b/route-rs-runtime/src/link/primitive/fork_link.rs
@@ -4,6 +4,7 @@ use crossbeam::atomic::AtomicCell;
 use crossbeam::crossbeam_channel;
 use crossbeam::crossbeam_channel::{Receiver, Sender};
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/route-rs-runtime/src/link/primitive/join_link.rs
+++ b/route-rs-runtime/src/link/primitive/join_link.rs
@@ -4,6 +4,7 @@ use crossbeam::atomic::AtomicCell;
 use crossbeam::crossbeam_channel;
 use crossbeam::crossbeam_channel::{Receiver, Sender};
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/route-rs-runtime/src/link/primitive/output_channel_link.rs
+++ b/route-rs-runtime/src/link/primitive/output_channel_link.rs
@@ -1,5 +1,6 @@
 use crate::link::{Link, LinkBuilder, PacketStream};
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 

--- a/route-rs-runtime/src/link/primitive/pcap.rs
+++ b/route-rs-runtime/src/link/primitive/pcap.rs
@@ -1,4 +1,5 @@
 use crate::link::{Link, LinkBuilder, PacketStream};
+use futures::ready;
 use futures::task::{Context, Poll};
 use futures::Stream;
 use pcap::{Capture, Offline};

--- a/route-rs-runtime/src/link/primitive/process_link.rs
+++ b/route-rs-runtime/src/link/primitive/process_link.rs
@@ -1,6 +1,7 @@
 use crate::link::{Link, LinkBuilder, PacketStream, ProcessLinkBuilder};
 use crate::processor::Processor;
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 

--- a/route-rs-runtime/src/link/primitive/queue_link.rs
+++ b/route-rs-runtime/src/link/primitive/queue_link.rs
@@ -5,6 +5,7 @@ use crossbeam::atomic::AtomicCell;
 use crossbeam::crossbeam_channel;
 use crossbeam::crossbeam_channel::{Receiver, Sender, TryRecvError};
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/route-rs-runtime/src/utils/test/packet_collectors.rs
+++ b/route-rs-runtime/src/utils/test/packet_collectors.rs
@@ -1,6 +1,7 @@
 use crate::link::PacketStream;
 use crossbeam::crossbeam_channel::Sender;
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::fmt::Debug;
 use std::pin::Pin;

--- a/route-rs-runtime/src/utils/test/packet_generators.rs
+++ b/route-rs-runtime/src/utils/test/packet_generators.rs
@@ -1,5 +1,6 @@
 use crate::link::PacketStream;
 use futures::prelude::*;
+use futures::ready;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
 use tokio::time::{interval, Duration, Interval};


### PR DESCRIPTION
This is a preliminary cut, for a draft commit
It does two things at once:
For runnables, it takes the vector passed in, your `all_runnables` and
appends the runnables returned from the link to the provided vector. You
may also choose to provide a `_` instead, and the runnables are
discarded.

For egressors, if you provide a single variable, it is declared as you
would expect, and represents the vector of egressors that is returned
from the link. If you provide a one or more variables inside of `[]`
square brackets, it automatically destructures the vector into those the
provided variables.

Examples
unpack!( let (runnables, egressors) = myLink::new().build; );

unpack!( let (runnables, [a, b, c]) = myLink::new().build; );

unpack!( let (_, egressors) = myLink::new().build; );

unpack!( let (_, [a,b,c]) = myLink::new().build; );