### PR TITLE
PHR: ArpHandler & ArpGenerator

### DIFF
--- a/examples/pi-home-router/src/arp/arp_generator.rs
+++ b/examples/pi-home-router/src/arp/arp_generator.rs
@@ -1,0 +1,184 @@
+use crate::types::InterfaceAnnotated;
+use route_rs_packets::{
+    ArpFrame, ArpOp, EthernetFrame, Ipv4Packet, MacAddr, ARP_ETHER_TYPE, IPV4_ETHER_TYPE,
+};
+use route_rs_runtime::processor::Processor;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+
+// TODO: This could also be called AddMacOrGenArp
+pub(crate) struct ArpGenerator {
+    arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>,
+}
+
+impl ArpGenerator {
+    pub fn new(arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>) -> Self {
+        ArpGenerator { arp_table }
+    }
+}
+
+impl Processor for ArpGenerator {
+    type Input = InterfaceAnnotated<EthernetFrame>;
+    type Output = InterfaceAnnotated<EthernetFrame>;
+
+    ///
+    /// From the ARP RFC: https://tools.ietf.org/html/rfc826
+    ///
+    /// As a packet is sent down through the network layers, routing determines the protocol address
+    /// of the next hop for the packet and on which piece of hardware it expects to find the station
+    /// with the immediate target protocol address. The Address Resolution module converts the
+    /// <protocol type, target protocol address> pair to a 48.bit Ethernet address. The Address
+    /// Resolution module tries to find this pair in a table. If it finds the pair, it gives the
+    /// corresponding 48.bit Ethernet address back to the caller which then transmits the packet.
+    ///
+    /// If the lookup for the (protocol type, protocol address) fails, it probably informs the
+    /// caller that it is throwing the packet away (on the assumption the packet will be
+    /// retransmitted by a higher network layer), and generates an Ethernet packet with a type field
+    /// of ether_type$ADDRESS_RESOLUTION. The Address Resolution module then sets
+    ///
+    /// Hardware Type: ares_hrd$Ethernet = 1
+    /// Protocol Type: type that is being resolved
+    /// Hardware Address Length: 6 (the number of bytes in a 48.bit Ethernet address)
+    /// Protocol Address Length: length of an address in that protocol
+    /// Op: ares_op$REQUEST = 1
+    /// Sender Hardware Address: the 48.bit ethernet address of itself
+    /// Sender Protocol Address: the protocol address of itself
+    /// Target Protocol Address: the protocol address of the machine that is trying to be accessed.
+    ///
+    /// It does not set Target Hardware Address to anything in particular, because it is this value
+    /// that it is trying to determine. It could set the Target Hardware Address to the broadcast
+    /// address (FF:FF:FF:FF:FF:FF) for the hardware (all ones in the case of the 10Mbit Ethernet)
+    /// if that makes it convenient for some aspect of the implementation.
+    ///
+    /// It then causes this packet to be broadcast to all stations on the Ethernet cable originally
+    /// determined by the routing mechanism.
+    ///
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        let mut frame = packet.packet;
+        match frame.ether_type() {
+            IPV4_ETHER_TYPE => {
+                let ipv4_packet = Ipv4Packet::try_from(frame).unwrap();
+
+                let ipv4_src_addr = ipv4_packet.src_addr();
+                let ipv4_dest_addr = ipv4_packet.dest_addr();
+                frame = EthernetFrame::encap_ipv4(ipv4_packet);
+
+                match self.arp_table.lock().unwrap().get(&ipv4_dest_addr) {
+                    Some(&dest_mac_addr) => {
+                        // We found a MacAddr for this (protocol type, target address) tuple!
+                        // Let's set it, and pass the packet along
+                        frame.set_dest_mac(dest_mac_addr);
+                        Some(InterfaceAnnotated::<EthernetFrame> {
+                            packet: frame,
+                            inbound_interface: packet.inbound_interface,
+                            outbound_interface: packet.outbound_interface,
+                        })
+                    }
+                    None => {
+                        // Couldn't find a match in the table, let's generate an ARP request
+                        let mut arp_request = ArpFrame::default();
+                        arp_request.set_hardware_type(1);
+                        arp_request.set_protocol_type(IPV4_ETHER_TYPE);
+                        arp_request.set_hardware_addr_len(6);
+                        arp_request.set_protocol_addr_len(4);
+                        arp_request.set_opcode(ArpOp::Request as u16);
+                        arp_request.set_sender_hardware_addr(frame.src_mac());
+                        arp_request.set_sender_protocol_addr(IpAddr::V4(ipv4_src_addr));
+                        arp_request.set_target_hardware_addr(MacAddr::new([0, 0, 0, 0, 0, 0]));
+                        arp_request.set_target_protocol_addr(IpAddr::V4(ipv4_dest_addr));
+                        frame = arp_request.frame();
+                        frame.set_ether_type(ARP_ETHER_TYPE);
+                        Some(InterfaceAnnotated::<EthernetFrame> {
+                            packet: frame,
+                            inbound_interface: packet.inbound_interface,
+                            outbound_interface: packet.outbound_interface,
+                        })
+                    }
+                }
+            }
+            // Ignore non-IPv4 packets
+            // TODO: add error logging?
+            _ => Some(InterfaceAnnotated::<EthernetFrame> {
+                packet: frame,
+                inbound_interface: packet.inbound_interface,
+                outbound_interface: packet.outbound_interface,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Interface;
+    use route_rs_packets::ARP_ETHER_TYPE;
+    use std::net::Ipv4Addr;
+
+    fn outgoing_ipv4(dest_ipv4: Ipv4Addr) -> EthernetFrame {
+        let mut packet = Ipv4Packet::empty();
+        packet.set_dest_addr(dest_ipv4);
+
+        let mut frame = EthernetFrame::encap_ipv4(packet);
+        frame.set_ether_type(IPV4_ETHER_TYPE);
+        frame
+    }
+
+    #[test]
+    fn found_translation_adds_mac() {
+        // Initialize IP to MAC translation table with one entry
+        let arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let dest_ipv4 = Ipv4Addr::new(1, 2, 3, 4);
+        let dest_mac = MacAddr::new([1, 2, 3, 4, 5, 6]);
+        arp_table.lock().unwrap().insert(dest_ipv4, dest_mac);
+
+        let output = ArpGenerator::new(arp_table)
+            .process(InterfaceAnnotated::<EthernetFrame> {
+                packet: outgoing_ipv4(dest_ipv4),
+                inbound_interface: Interface::Wan,
+                outbound_interface: Interface::Lan,
+            })
+            .unwrap();
+
+        assert_eq!(output.packet.ether_type(), IPV4_ETHER_TYPE);
+        assert_eq!(output.packet.dest_mac(), dest_mac);
+        assert_eq!(
+            Ipv4Packet::try_from(output.packet).unwrap().dest_addr(),
+            dest_ipv4
+        );
+        assert_eq!(output.inbound_interface, Interface::Wan);
+        assert_eq!(output.outbound_interface, Interface::Lan);
+    }
+
+    #[test]
+    fn missing_translation_generates_arp_request() {
+        // Initialize empty IP to MAC translation table
+        let arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let dest_ipv4 = Ipv4Addr::new(1, 2, 3, 4);
+
+        let output = ArpGenerator::new(arp_table)
+            .process(InterfaceAnnotated::<EthernetFrame> {
+                packet: outgoing_ipv4(dest_ipv4),
+                inbound_interface: Interface::Wan,
+                outbound_interface: Interface::Lan,
+            })
+            .unwrap();
+
+        assert_eq!(output.packet.ether_type(), ARP_ETHER_TYPE);
+        assert_eq!(output.packet.dest_mac(), MacAddr::new([0, 0, 0, 0, 0, 0]));
+        assert_eq!(
+            Ipv4Packet::try_from(output.packet.clone()).unwrap_err(),
+            "Packet has incorrect version, is not Ipv4Packet"
+        );
+        let arp_request = ArpFrame::try_from(output.packet.clone()).unwrap();
+        assert_eq!(arp_request.protocol_type(), IPV4_ETHER_TYPE);
+        assert_eq!(arp_request.target_ipv4_addr().unwrap(), dest_ipv4);
+        assert_eq!(output.inbound_interface, Interface::Wan);
+        assert_eq!(output.outbound_interface, Interface::Lan);
+    }
+}

--- a/examples/pi-home-router/src/arp/arp_handler.rs
+++ b/examples/pi-home-router/src/arp/arp_handler.rs
@@ -1,0 +1,212 @@
+use crate::types::InterfaceAnnotated;
+use route_rs_packets::{ArpFrame, ArpHardwareType, ArpOp, EthernetFrame, MacAddr, IPV4_ETHER_TYPE};
+use route_rs_runtime::processor::Processor;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+
+// TODO: We need to respond to ARP requests that are targeted at the router.
+// Where is this state stored? How to we access it?
+const ROUTER_IPV4_ADDR: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
+pub(crate) struct ArpHandler {
+    arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>,
+}
+
+impl ArpHandler {
+    pub fn new(arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>) -> Self {
+        ArpHandler { arp_table }
+    }
+}
+
+impl Processor for ArpHandler {
+    type Input = InterfaceAnnotated<EthernetFrame>;
+    type Output = InterfaceAnnotated<EthernetFrame>;
+
+    ///
+    /// From the ARP RFC: https://tools.ietf.org/html/rfc826
+    /// Handler assumes it receives ARP packets
+    ///
+    /// ?Do I have the hardware type in ar$hrd?
+    /// Yes: (almost definitely)
+    ///     [optionally check the hardware length ar$hln]
+    ///     ?Do I speak the protocol in ar$pro?
+    ///     Yes:
+    ///         [optionally check the protocol length ar$pln]
+    ///         Merge_flag := false
+    ///         If the pair <protocol type, sender protocol address> is already in my translation
+    ///             table, update the sender hardware address field of the entry with the new
+    ///             information in the packet and set Merge_flag to true.
+    ///         ?Am I the target protocol address?
+    ///         Yes:
+    ///             If Merge_flag is false, add the triplet <protocol type, sender protocol address,
+    ///                 sender hardware address> to the translation table.
+    ///             ?Is the opcode ares_op$REQUEST?  (NOW look at the opcode!!)
+    ///             Yes:
+    ///                 Swap hardware and protocol fields, putting the local hardware and protocol
+    ///                     addresses in the sender fields.
+    ///                 Set the ar$op field to ares_op$REPLY
+    ///                 Send the packet to the (new) target hardware address on the same hardware on
+    ///                     which the request was received.
+    ///
+    fn process(&mut self, packet: Self::Input) -> Option<Self::Output> {
+        let mut arp_frame = ArpFrame::try_from(packet.packet).unwrap();
+        if arp_frame.hardware_type() == ArpHardwareType::Ethernet as u16 {
+            let protocol_type = arp_frame.protocol_type();
+
+            if protocol_type == IPV4_ETHER_TYPE {
+                let mut updated_translation_table = false;
+                let sender_ipv4_address = arp_frame.sender_ipv4_addr().unwrap();
+                let sender_mac_address = arp_frame.sender_mac_addr().unwrap();
+
+                if !self
+                    .arp_table
+                    .lock()
+                    .unwrap()
+                    .contains_key(&sender_ipv4_address)
+                {
+                    self.arp_table
+                        .lock()
+                        .unwrap()
+                        .insert(sender_ipv4_address, sender_mac_address);
+                    updated_translation_table = true;
+                }
+
+                let target_ipv4_address = arp_frame.target_ipv4_addr().unwrap();
+                if target_ipv4_address == ROUTER_IPV4_ADDR {
+                    if !updated_translation_table {
+                        self.arp_table
+                            .lock()
+                            .unwrap()
+                            .insert(sender_ipv4_address, sender_mac_address);
+                    }
+
+                    if arp_frame.opcode() == ArpOp::Request as u16 {
+                        // Generate response ARP frame
+                        arp_frame.set_target_hardware_addr(sender_mac_address);
+                        arp_frame.set_target_protocol_addr(IpAddr::V4(sender_ipv4_address));
+                        // TODO: how can I find this machine's MacAddr?
+                        // Will it be pre-populated in the ARP table?
+                        arp_frame.set_sender_hardware_addr(MacAddr::new([0, 0, 0, 0, 0, 0]));
+                        arp_frame.set_sender_protocol_addr(IpAddr::V4(ROUTER_IPV4_ADDR));
+                        arp_frame.set_opcode(ArpOp::Reply as u16);
+
+                        return Some(InterfaceAnnotated::<EthernetFrame> {
+                            packet: arp_frame.frame(),
+                            inbound_interface: packet.inbound_interface,
+                            outbound_interface: packet.outbound_interface,
+                        });
+                    }
+                }
+            }
+        }
+        Some(InterfaceAnnotated::<EthernetFrame> {
+            packet: arp_frame.frame(),
+            inbound_interface: packet.inbound_interface,
+            outbound_interface: packet.outbound_interface,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Interface;
+    use route_rs_packets::ARP_ETHER_TYPE;
+
+    fn stub_annotated_input(frame: EthernetFrame) -> InterfaceAnnotated<EthernetFrame> {
+        InterfaceAnnotated::<EthernetFrame> {
+            packet: frame,
+            inbound_interface: Interface::Wan,
+            outbound_interface: Interface::Lan,
+        }
+    }
+
+    fn stub_arp_frame(sender_ipv4_addr: Ipv4Addr, sender_mac_addr: MacAddr) -> ArpFrame {
+        let mut arp_frame = ArpFrame::default();
+        arp_frame.set_hardware_type(ArpHardwareType::Ethernet as u16);
+        arp_frame.set_protocol_type(IPV4_ETHER_TYPE);
+        arp_frame.set_sender_protocol_addr(IpAddr::V4(sender_ipv4_addr));
+        arp_frame.set_sender_hardware_addr(sender_mac_addr);
+        arp_frame.set_opcode(ArpOp::Request as u16);
+        let mut frame = arp_frame.frame();
+        frame.set_ether_type(ARP_ETHER_TYPE);
+        ArpFrame::try_from(frame).unwrap()
+    }
+
+    #[test]
+    fn new_ip_mac_pairs_added_to_arp_table() {
+        let sender_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+        let sender_mac_addr = MacAddr::new([1, 2, 3, 4, 5, 6]);
+
+        // Initialize empty IP to MAC translation table
+        let arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        ArpHandler::new(arp_table.clone())
+            .process(stub_annotated_input(
+                stub_arp_frame(sender_ipv4_addr, sender_mac_addr).frame(),
+            ))
+            .unwrap();
+
+        // Arp table sniffed the new pair
+        assert_eq!(
+            arp_table.lock().unwrap().get(&sender_ipv4_addr).unwrap(),
+            &sender_mac_addr
+        );
+    }
+
+    #[test]
+    fn arp_requests_not_addressed_to_router_gets_no_reply() {
+        let sender_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+        let sender_mac_addr = MacAddr::new([1, 2, 3, 4, 5, 6]);
+
+        let output = ArpHandler::new(Arc::new(Mutex::new(HashMap::new())))
+            .process(stub_annotated_input(
+                stub_arp_frame(sender_ipv4_addr, sender_mac_addr).frame(),
+            ))
+            .unwrap();
+
+        // Not addressed to router, so ARP frame is unchanged
+        assert_eq!(output.packet.ether_type(), ARP_ETHER_TYPE);
+        let output_arp_frame = ArpFrame::try_from(output.packet).unwrap();
+        assert_eq!(output_arp_frame.opcode(), ArpOp::Request as u16);
+        assert_eq!(
+            output_arp_frame.sender_ipv4_addr().unwrap(),
+            sender_ipv4_addr
+        );
+        assert_eq!(output_arp_frame.sender_mac_addr().unwrap(), sender_mac_addr);
+    }
+
+    #[test]
+    fn arp_requests_addressed_to_router_gets_reply() {
+        let sender_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+        let sender_mac_addr = MacAddr::new([1, 2, 3, 4, 5, 6]);
+
+        let mut arp_frame = stub_arp_frame(sender_ipv4_addr, sender_mac_addr);
+        arp_frame.set_target_protocol_addr(IpAddr::V4(ROUTER_IPV4_ADDR));
+
+        let output = ArpHandler::new(Arc::new(Mutex::new(HashMap::new())))
+            .process(stub_annotated_input(arp_frame.frame()))
+            .unwrap();
+
+        // Addressed to router, so ARP frame is a Reply, with updated sender values
+        assert_eq!(output.packet.ether_type(), ARP_ETHER_TYPE);
+        let output_arp_frame = ArpFrame::try_from(output.packet).unwrap();
+        assert_eq!(output_arp_frame.opcode(), ArpOp::Reply as u16);
+        assert_eq!(
+            output_arp_frame.sender_ipv4_addr().unwrap(),
+            ROUTER_IPV4_ADDR
+        );
+        // assert_eq!(
+        //     output_arp_frame.sender_mac_addr().unwrap(),
+        //     MacAddr::new([0, 0, 0, 0, 0, 0])
+        // );
+        assert_eq!(
+            output_arp_frame.target_ipv4_addr().unwrap(),
+            sender_ipv4_addr
+        );
+        assert_eq!(output_arp_frame.target_mac_addr().unwrap(), sender_mac_addr);
+    }
+}

--- a/examples/pi-home-router/src/arp/mod.rs
+++ b/examples/pi-home-router/src/arp/mod.rs
@@ -1,0 +1,5 @@
+mod arp_generator;
+pub(crate) use self::arp_generator::ArpGenerator;
+
+mod arp_handler;
+pub(crate) use self::arp_handler::ArpHandler;

--- a/examples/pi-home-router/src/main.rs
+++ b/examples/pi-home-router/src/main.rs
@@ -1,3 +1,4 @@
+mod arp;
 mod interface;
 mod router;
 mod types;

--- a/examples/pi-home-router/src/router.rs
+++ b/examples/pi-home-router/src/router.rs
@@ -1,4 +1,11 @@
-use route_rs_runtime::link::{Link, LinkBuilder, PacketStream};
+use crate::arp::{ArpGenerator, ArpHandler};
+use route_rs_packets::MacAddr;
+use route_rs_runtime::link::primitive::ProcessLink;
+use route_rs_runtime::link::{Link, LinkBuilder, PacketStream, ProcessLinkBuilder};
+use route_rs_runtime::utils::test::packet_generators::immediate_stream;
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::{Arc, Mutex};
 
 /// Top level structure, implements LinkBuilder so it can be run by the test harness
 #[derive(Default)]
@@ -6,6 +13,15 @@ pub(crate) struct Router {
     host: Option<String>,
     lan: Option<String>,
     wan: Option<String>,
+
+    // TODO: investigate/discuss concurrency options
+    // https://doc.rust-lang.org/std/sync/struct.RwLock.html
+    // https://docs.rs/chashmap/2.2.2/chashmap/
+    // https://github.com/jonhoo/rust-evmap
+    // https://github.com/jonhoo/flurry
+    /// Top-level ARP table reference.
+    /// Links that require a reference should clone this Arc.
+    arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>,
 }
 
 impl Router {
@@ -14,6 +30,7 @@ impl Router {
             host: None,
             lan: None,
             wan: None,
+            arp_table: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -22,6 +39,7 @@ impl Router {
             host: Some(String::from(host)),
             lan: self.lan,
             wan: self.wan,
+            arp_table: self.arp_table,
         }
     }
 
@@ -30,6 +48,7 @@ impl Router {
             host: self.host,
             lan: Some(String::from(lan)),
             wan: self.wan,
+            arp_table: self.arp_table,
         }
     }
 
@@ -38,6 +57,7 @@ impl Router {
             host: self.host,
             lan: self.lan,
             wan: Some(String::from(wan)),
+            arp_table: self.arp_table,
         }
     }
 }
@@ -55,6 +75,19 @@ impl LinkBuilder<(), ()> for Router {
     fn build_link(self) -> Link<()> {
         // Return an empty link for now. As we build the link, this should be returning
         // all the relevant runnables, and no egressors(Since our router has none)
+
+        // TODO: wire up from protocol classifier
+        let _arp_handler = ProcessLink::new()
+            .ingressor(immediate_stream(vec![]))
+            .processor(ArpHandler::new(self.arp_table.clone()))
+            .build_link();
+
+        // TODO: not sure where to put ArpGenerator
+        let _arp_generator = ProcessLink::new()
+            .ingressor(immediate_stream(vec![]))
+            .processor(ArpGenerator::new(self.arp_table))
+            .build_link();
+
         (vec![], vec![])
     }
 }

--- a/examples/pi-home-router/src/types.rs
+++ b/examples/pi-home-router/src/types.rs
@@ -16,7 +16,7 @@ pub(crate) struct InterfaceAnnotated<P: Packet> {
 ///
 /// An enum to label the inbound and outbound interfaces with, None is used to
 /// denote an unknown or yet-to-be determined interface.
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, PartialEq)]
 pub enum Interface {
     Host,
     Wan,


### PR DESCRIPTION
Introduces 2 new Links to PHR, `ArpHandler` and `ArpGenerator` (not tied to those names). They implement handling and generating ARP requests respectively, using `route-rs-packets::ArpFrame` and a shared `arp_table: Arc<Mutex<HashMap<Ipv4Addr, MacAddr>>>`. There are plenty of things that can be improved, but I believe this implementation is functional with a minimal test suite. Feel free to skim the code for `TODO`s and leave your 2 cents.